### PR TITLE
Fix duplicate provider registration in AppServiceProvider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,7 +15,6 @@ class AppServiceProvider extends ServiceProvider
     {
         if ($this->app->environment('local') && class_exists(TelescopeServiceProvider::class)) {
             $this->app->register(TelescopeServiceProvider::class);
-            $this->app->register(TelescopeServiceProvider::class);
         }
 
     }


### PR DESCRIPTION
## Summary
- avoid registering TelescopeServiceProvider twice

## Testing
- `php artisan test` *(fails: php not installed)*