### PR TITLE
Add first/last name fields with blind indexes

### DIFF
--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Pages\Auth;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Pages\Auth\EditProfile as BaseEditProfile;
+
+class EditProfile extends BaseEditProfile
+{
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                $this->getEmailFormComponent()->disabled(),
+                TextInput::make('first_name')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('last_name')
+                    ->required()
+                    ->maxLength(255),
+            ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,8 @@ class User extends Authenticatable
     protected $fillable = [
         'email',
         'password',
+        'first_name',
+        'last_name',
     ];
 
     protected $hidden = [
@@ -31,9 +33,13 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
         'email' => 'encrypted', // This handles encryption/decryption
+        'first_name' => 'encrypted',
+        'last_name' => 'encrypted',
     ];
 
     protected $blind = [
         'email',
+        'first_name',
+        'last_name',
     ];
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Pages\Auth\EditProfile;
 use App\Filament\Pages\Auth\Register;
 use App\Filament\Pages\Auth\RequestPasswordReset;
 use Filament\Http\Middleware\Authenticate;
@@ -31,6 +32,7 @@ class AdminPanelProvider extends PanelProvider
             ->passwordReset(RequestPasswordReset::class)
             ->registration(Register::class)
             ->login()
+            ->profile(EditProfile::class)
             ->colors([
                 'primary' => Color::Slate,
             ])

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,6 +15,10 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->text('email');
             $table->char('email_blind_index', 64)->unique();
+            $table->text('first_name')->nullable();
+            $table->char('first_name_blind_index', 64)->index()->nullable();
+            $table->text('last_name')->nullable();
+            $table->char('last_name_blind_index', 64)->index()->nullable();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/resources/views/filament/pages/auth/edit-profile.blade.php
+++ b/resources/views/filament/pages/auth/edit-profile.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+
+</x-filament-panels::page>

--- a/tests/Feature/UserBlindIndexLookupTest.php
+++ b/tests/Feature/UserBlindIndexLookupTest.php
@@ -13,11 +13,13 @@ class UserBlindIndexLookupTest extends TestCase
     public function test_find_by_email_works_with_blind_index()
     {
         $email = fake()->unique()->safeEmail();
-        $name = fake()->name();
+        $firstName = 'John';
+        $lastName = 'Doe';
 
         // Create user as normal
         $user = User::create([
-            'name' => $name,
+            'first_name' => $firstName,
+            'last_name' => $lastName,
             'email' => $email,
             'password' => bcrypt('password'),
         ]);

--- a/tests/Feature/UserEmailBlindIndexTest.php
+++ b/tests/Feature/UserEmailBlindIndexTest.php
@@ -15,11 +15,13 @@ class UserEmailBlindIndexTest extends TestCase
     {
         // Given: generate a random but reproducible test email
         $plaintextEmail = fake()->unique()->safeEmail();
-        $userName = fake()->name();
+        $firstName = 'John';
+        $lastName = 'Doe';
 
         // When
         $user = User::create([
-            'name' => $userName,
+            'first_name' => $firstName,
+            'last_name' => $lastName,
             'email' => $plaintextEmail,
             'password' => bcrypt('password'),
         ]);

--- a/tests/Feature/UserEmailEncryptionTest.php
+++ b/tests/Feature/UserEmailEncryptionTest.php
@@ -16,14 +16,16 @@ class UserEmailEncryptionTest extends TestCase
     {
         // Given (use Faker for dynamic values)
         $plaintextEmail = fake()->unique()->safeEmail();
-        $userName = fake()->name();
+        $firstName = 'John';
+        $lastName = 'Doe';
         $normalized = Str::of($plaintextEmail)->lower()->trim();
         $hmacKey = base64_decode(Str::after(env('APP_BLIND_INDEX_KEY'), 'base64:'));
         $expectedBlindIndex = hash_hmac('sha256', $normalized, $hmacKey);
 
         // When
         $user = User::create([
-            'name' => $userName,
+            'first_name' => $firstName,
+            'last_name' => $lastName,
             'email' => $plaintextEmail,
             'password' => bcrypt('password'),
         ]);
@@ -38,7 +40,7 @@ class UserEmailEncryptionTest extends TestCase
             $rawDbUser->email
         );
         $this->assertStringNotContainsStringIgnoringCase(
-            explode(' ', strtolower($userName))[0],
+            strtolower($firstName),
             $rawDbUser->email
         );
 

--- a/tests/Feature/UserNameBlindIndexTest.php
+++ b/tests/Feature/UserNameBlindIndexTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class UserNameBlindIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_first_and_last_name_blind_indexes_are_created()
+    {
+        $firstName = 'Alice';
+        $lastName = 'Smith';
+        $email = fake()->unique()->safeEmail();
+
+        $user = User::create([
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'email' => $email,
+            'password' => bcrypt('password'),
+        ]);
+
+        $rawDbUser = \DB::table('users')->find($user->id);
+
+        $normalizedFirst = Str::of($firstName)->lower()->trim();
+        $normalizedLast = Str::of($lastName)->lower()->trim();
+        $hmacKey = base64_decode(Str::after(env('APP_BLIND_INDEX_KEY'), 'base64:'));
+        $expectedFirst = hash_hmac('sha256', $normalizedFirst, $hmacKey);
+        $expectedLast = hash_hmac('sha256', $normalizedLast, $hmacKey);
+
+        $this->assertEquals($expectedFirst, $rawDbUser->first_name_blind_index);
+        $this->assertEquals($expectedLast, $rawDbUser->last_name_blind_index);
+
+        $foundFirst = User::findByBlindIndex('first_name', $firstName);
+        $foundLast = User::findByBlindIndex('last_name', $lastName);
+
+        $this->assertNotNull($foundFirst);
+        $this->assertNotNull($foundLast);
+        $this->assertEquals($user->id, $foundFirst->id);
+        $this->assertEquals($user->id, $foundLast->id);
+    }
+}


### PR DESCRIPTION
## Summary
- split `name` into `first_name` and `last_name`
- add blind indexes for new fields
- encrypt and index names in `User` model
- cover with feature tests

## Testing
- `phpunit` *(fails: command not found)*