### PR TITLE
Update PHPUnit environment to use in-memory and array drivers

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -45,6 +45,18 @@ return [
             'search_path' => 'public',
             'sslmode' => 'prefer',
         ],
+//for testing
+        'sqlite' => [
+            'driver' => 'sqlite',
+            'url' => env('DB_URL'),
+            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'prefix' => '',
+            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+            'busy_timeout' => null,
+            'journal_mode' => null,
+            'synchronous' => null,
+        ],
+
 
     ],
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,13 +21,13 @@
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_STORE" value="redis"/>
-        <env name="DB_CONNECTION" value="pgsql"/>
-        <env name="DB_DATABASE" value="laravel"/>
-        <env name="MAIL_MAILER" value="log"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
-        <env name="QUEUE_CONNECTION" value="redis"/>
-        <env name="SESSION_DRIVER" value="redis"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Replaced Redis and Postgres-based configurations with in-memory SQLite and array-based alternatives for a faster and isolated testing environment. This ensures tests run consistently without relying on external services.
