### PR TITLE
Fix BlindIndexUserProvider tests

### DIFF
--- a/tests/Feature/BlindIndexUserProviderTest.php
+++ b/tests/Feature/BlindIndexUserProviderTest.php
@@ -4,11 +4,13 @@ namespace Tests\Feature;
 
 use App\Auth\BlindIndexUserProvider;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 class BlindIndexUserProviderTest extends TestCase
 {
+    use RefreshDatabase;
     public function test_retrieve_by_credentials_uses_blind_index(): void
     {
         $email = fake()->unique()->safeEmail();


### PR DESCRIPTION
## Summary
- refresh database for blind index provider tests so user table exists

## Testing
- `php artisan test` *(fails: `php: command not found`)*