### PR TITLE
Refactor naming and add notification tests

### DIFF
--- a/app/Models/Traits/HasDisplayName.php
+++ b/app/Models/Traits/HasDisplayName.php
@@ -4,39 +4,33 @@ namespace App\Models\Traits;
 
 use Illuminate\Support\Str;
 
-trait GenerateName
+trait HasDisplayName
 {
     public function getNameAttribute(): string
     {
-        // If 'name' attribute exists and is not empty
         if (! empty($this->name ?? null)) {
             return Str::title($this->name);
         }
 
-        // If both 'first_name' and 'last_name' exist
         if (! empty($this->first_name ?? null) && ! empty($this->last_name ?? null)) {
             return Str::title("{$this->first_name} {$this->last_name}");
         }
 
-        // If only 'first_name' exists
         if (! empty($this->first_name ?? null)) {
             return Str::title($this->first_name);
         }
 
-        // If only 'last_name' exists
         if (! empty($this->last_name ?? null)) {
             return Str::title($this->last_name);
         }
 
-        // If 'email' exists, extract the part before '@' and format it
         if (! empty($this->email ?? null)) {
-            $localPart = Str::before($this->email, '@');
-            $formatted = preg_replace('/[._-]+/', ' ', $localPart);
+            $local = Str::before($this->email, '@');
+            $clean = preg_replace('/[._-]+/', ' ', $local);
 
-            return Str::title($formatted);
+            return Str::title($clean);
         }
 
-        // Fallback to a default name
         return 'User';
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Models\Traits\GenerateName;
+use App\Models\Traits\HasDisplayName;
 use App\Models\Traits\HasBlindIndex;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -16,7 +16,7 @@ use Illuminate\Notifications\Notifiable;
  */
 class User extends Authenticatable implements MustVerifyEmail
 {
-    use GenerateName, HasBlindIndex, HasFactory, HasUuids, Notifiable, SoftDeletes;
+    use HasDisplayName, HasBlindIndex, HasFactory, HasUuids, Notifiable, SoftDeletes;
 
     protected $fillable = [
         'email',

--- a/tests/Feature/NotificationEncryptionTest.php
+++ b/tests/Feature/NotificationEncryptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Notifications\EncryptedResetPasswordNotification;
+use App\Notifications\EncryptedVerifyEmailNotification;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Tests\TestCase;
+
+class NotificationEncryptionTest extends TestCase
+{
+    public function test_notifications_implement_encryption(): void
+    {
+        $reset = new EncryptedResetPasswordNotification('token');
+        $verify = new EncryptedVerifyEmailNotification();
+
+        $this->assertInstanceOf(ShouldBeEncrypted::class, $reset);
+        $this->assertInstanceOf(ShouldBeEncrypted::class, $verify);
+    }
+}

--- a/tests/Feature/UserDisplayNameTest.php
+++ b/tests/Feature/UserDisplayNameTest.php
@@ -5,7 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Tests\TestCase;
 
-class UserGenerateNameTest extends TestCase
+class UserDisplayNameTest extends TestCase
 {
     public function test_generates_name_from_first_and_last_name(): void
     {


### PR DESCRIPTION
## Summary
- rename trait `GenerateName` to `HasDisplayName`
- update user model to use new trait
- rename associated test file
- add test ensuring notification classes implement `ShouldBeEncrypted`

## Testing
- `phpunit` *(fails: `php: command not found`)*