### PR TITLE
Add pesel uniqueness tests

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->text('last_name')->nullable();
             $table->char('last_name_blind_index', 64)->index()->nullable();
             $table->text('pesel')->nullable();
-            $table->char('pesel_blind_index', 64)->index()->nullable();
+            $table->char('pesel_blind_index', 64)->unique()->nullable();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/tests/Feature/UserPeselUniqueTest.php
+++ b/tests/Feature/UserPeselUniqueTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserPeselUniqueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_allows_multiple_users_with_null_pesel(): void
+    {
+        User::create([
+            'email' => fake()->unique()->safeEmail(),
+            'password' => bcrypt('password'),
+        ]);
+
+        User::create([
+            'email' => fake()->unique()->safeEmail(),
+            'password' => bcrypt('password'),
+        ]);
+
+        $this->assertDatabaseCount('users', 2);
+    }
+
+    public function test_duplicate_pesel_is_invalid(): void
+    {
+        $pesel = '44051401359';
+
+        User::create([
+            'email' => fake()->unique()->safeEmail(),
+            'password' => bcrypt('password'),
+            'pesel' => $pesel,
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        User::create([
+            'email' => fake()->unique()->safeEmail(),
+            'password' => bcrypt('password'),
+            'pesel' => $pesel,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce uniqueness on pesel_blind_index
- test that null pesel can be reused but duplicate pesel is rejected

## Testing
- `phpunit --filter=UserPeselUniqueTest` *(fails: php not installed)*