### PR TITLE
Add blind index migration helper

### DIFF
--- a/app/Database/Migrations/Traits/HasBlindIndexColumns.php
+++ b/app/Database/Migrations/Traits/HasBlindIndexColumns.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Database\Migrations\Traits;
+
+use Illuminate\Database\Schema\Blueprint;
+
+trait HasBlindIndexColumns
+{
+    protected function addBlindIndexColumns(Blueprint $table, array $fields): void
+    {
+        foreach ($fields as $field => $options) {
+            $unique = false;
+            $nullable = false;
+
+            if (is_bool($options)) {
+                $unique = $options;
+            } elseif (is_array($options)) {
+                $unique = $options['unique'] ?? false;
+                $nullable = $options['nullable'] ?? false;
+            }
+
+            $textColumn = $table->text($field);
+            if ($nullable) {
+                $textColumn->nullable();
+            }
+
+            $indexColumn = $table->char($field . '_blind_index', 64);
+            if ($nullable) {
+                $indexColumn->nullable();
+            }
+
+            if ($unique) {
+                $indexColumn->unique();
+            } else {
+                $indexColumn->index();
+            }
+        }
+    }
+}

--- a/app/Models/Traits/HasBlindIndex.php
+++ b/app/Models/Traits/HasBlindIndex.php
@@ -21,7 +21,13 @@ trait HasBlindIndex
      */
     public function getBlindIndexAttributes(): array
     {
-        return property_exists($this, 'blind') ? $this->blind : [];
+        if (! property_exists($this, 'blind')) {
+            return [];
+        }
+
+        $blind = $this->blind;
+
+        return array_is_list($blind) ? $blind : array_keys($blind);
     }
 
     public static function makeBlindIndex(string $value): string

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,9 +41,9 @@ class User extends Authenticatable implements MustVerifyEmail
     ];
 
     protected $blind = [
-        'email',
-        'first_name',
-        'last_name',
-        'pesel',
+        'email' => ['unique' => true],
+        'first_name' => ['nullable' => true],
+        'last_name' => ['nullable' => true],
+        'pesel' => ['unique' => true, 'nullable' => true],
     ];
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -3,9 +3,11 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Database\Migrations\Traits\HasBlindIndexColumns;
 
 return new class extends Migration
 {
+    use HasBlindIndexColumns;
     /**
      * Run the migrations.
      */
@@ -13,14 +15,15 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->text('email'); //instruction - create reusable trait; every blind indexed field could be unique or not - distinguish them in the array; for ever one of them create encrypted db text, but without _blind_index suffix
-            $table->char('email_blind_index', 64)->unique();
-            $table->text('first_name')->nullable();
-            $table->char('first_name_blind_index', 64)->index()->nullable();
-            $table->text('last_name')->nullable();
-            $table->char('last_name_blind_index', 64)->index()->nullable();
-            $table->text('pesel')->nullable();
-            $table->char('pesel_blind_index', 64)->unique()->nullable();
+
+            // instruction - create reusable trait; every blind indexed field could be unique or not - distinguish them in the array; for ever one of them create encrypted db text, but without _blind_index suffix
+            $this->addBlindIndexColumns($table, [
+                'email' => ['unique' => true],
+                'first_name' => ['nullable' => true],
+                'last_name' => ['nullable' => true],
+                'pesel' => ['unique' => true, 'nullable' => true],
+            ]);
+
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();


### PR DESCRIPTION
## Summary
- create `HasBlindIndexColumns` trait for migrations
- support associative blind index arrays in models
- update user migration and model to use new trait

## Testing
- `php artisan test` *(fails: `php` not found)*