### PR TITLE
Fix blind index migration test

### DIFF
--- a/app/Database/Migrations/Traits/HasBlindIndexColumns.php
+++ b/app/Database/Migrations/Traits/HasBlindIndexColumns.php
@@ -24,7 +24,7 @@ trait HasBlindIndexColumns
                 $textColumn->nullable();
             }
 
-            $indexColumn = $table->char($field . '_blind_index', 64);
+            $indexColumn = $table->char($field . '_blind_index', 64)->default('');
             if ($nullable) {
                 $indexColumn->nullable();
             }


### PR DESCRIPTION
## Summary
- allow blind index columns to default to an empty string so inserts work without specifying values

## Testing
- `composer test` *(fails: vendor directory missing)*