### PR TITLE
Fix blind index migration test

### DIFF
--- a/app/Database/Migrations/Traits/HasBlindIndexColumns.php
+++ b/app/Database/Migrations/Traits/HasBlindIndexColumns.php
@@ -27,6 +27,8 @@ trait HasBlindIndexColumns
             $indexColumn = $table->char($field . '_blind_index', 64);
             if ($nullable) {
                 $indexColumn->nullable();
+            } else {
+                $indexColumn->default('');
             }
 
             if ($unique) {


### PR DESCRIPTION
## Summary
- allow blind index columns to default to an empty string only when the field is not nullable

## Testing
- `composer test` *(fails: vendor directory missing)*