### PR TITLE
Enable soft deletes and test models

### DIFF
--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -2,8 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Organization extends Model
 {
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $guarded = [];
 }

--- a/app/Models/Personnel.php
+++ b/app/Models/Personnel.php
@@ -2,9 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Personnel extends Model
 {
+    use HasFactory, HasUuids, SoftDeletes;
+
     protected $table = 'personnel';
+    protected $guarded = [];
 }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -2,8 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Unit extends Model
 {
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $guarded = [];
 }

--- a/tests/Feature/ModelSoftDeleteTest.php
+++ b/tests/Feature/ModelSoftDeleteTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\Unit;
+use App\Models\Personnel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ModelSoftDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_models_are_soft_deleted()
+    {
+        $org = new Organization();
+        $org->save();
+
+        $unit = new Unit();
+        $unit->organization_id = $org->id;
+        $unit->save();
+
+        $user = User::factory()->create();
+
+        $personnel = new Personnel();
+        $personnel->unit_id = $unit->id;
+        $personnel->user_id = $user->id;
+        $personnel->save();
+
+        $org->delete();
+        $unit->delete();
+        $personnel->delete();
+        $user->delete();
+
+        $this->assertSoftDeleted('organizations', ['id' => $org->id]);
+        $this->assertSoftDeleted('units', ['id' => $unit->id]);
+        $this->assertSoftDeleted('personnel', ['id' => $personnel->id]);
+        $this->assertSoftDeleted('users', ['id' => $user->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- add SoftDeletes to Organization, Unit, and Personnel models
- cover soft deletion behaviour with a new test

## Testing
- `composer test` *(fails: composer not found)*