### PR TITLE
Refactor blind index migration options

### DIFF
--- a/app/Database/Migrations/Enums/BlindIndexType.php
+++ b/app/Database/Migrations/Enums/BlindIndexType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Database\Migrations\Enums;
+
+enum BlindIndexType
+{
+    case NULLABLE;
+    case NOT_NULL;
+    case NOT_NULL_UNIQUE;
+    case NULLABLE_UNIQUE;
+
+    public function isNullable(): bool
+    {
+        return match ($this) {
+            self::NULLABLE, self::NULLABLE_UNIQUE => true,
+            default => false,
+        };
+    }
+
+    public function isUnique(): bool
+    {
+        return match ($this) {
+            self::NOT_NULL_UNIQUE, self::NULLABLE_UNIQUE => true,
+            default => false,
+        };
+    }
+}

--- a/app/Database/Migrations/Traits/HasBlindIndexColumns.php
+++ b/app/Database/Migrations/Traits/HasBlindIndexColumns.php
@@ -3,6 +3,7 @@
 namespace App\Database\Migrations\Traits;
 
 use Illuminate\Database\Schema\Blueprint;
+use App\Database\Migrations\Enums\BlindIndexType;
 
 trait HasBlindIndexColumns
 {
@@ -12,7 +13,10 @@ trait HasBlindIndexColumns
             $unique = false;
             $nullable = false;
 
-            if (is_bool($options)) {
+            if ($options instanceof BlindIndexType) {
+                $unique = $options->isUnique();
+                $nullable = $options->isNullable();
+            } elseif (is_bool($options)) {
                 $unique = $options;
             } elseif (is_array($options)) {
                 $unique = $options['unique'] ?? false;

--- a/app/Filament/Resources/PersonnelResource.php
+++ b/app/Filament/Resources/PersonnelResource.php
@@ -7,8 +7,10 @@ use App\Filament\Resources\PersonnelResource\RelationManagers;
 use App\Models\Personnel;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Forms\Components\Select;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
@@ -23,7 +25,12 @@ class PersonnelResource extends Resource
     {
         return $form
             ->schema([
-                //
+                Select::make('unit_id')
+                    ->relationship('unit', 'id')
+                    ->required(),
+                Select::make('user_id')
+                    ->relationship('user', 'id')
+                    ->required(),
             ]);
     }
 
@@ -31,7 +38,9 @@ class PersonnelResource extends Resource
     {
         return $table
             ->columns([
-                //
+                TextColumn::make('id')->label('ID'),
+                TextColumn::make('unit.id')->label('Unit ID'),
+                TextColumn::make('user.id')->label('User ID'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/UnitResource.php
+++ b/app/Filament/Resources/UnitResource.php
@@ -7,8 +7,10 @@ use App\Filament\Resources\UnitResource\RelationManagers;
 use App\Models\Unit;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Forms\Components\Select;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
@@ -23,7 +25,9 @@ class UnitResource extends Resource
     {
         return $form
             ->schema([
-                //
+                Select::make('organization_id')
+                    ->relationship('organization', 'id')
+                    ->required(),
             ]);
     }
 
@@ -31,7 +35,8 @@ class UnitResource extends Resource
     {
         return $table
             ->columns([
-                //
+                TextColumn::make('id')->label('ID'),
+                TextColumn::make('organization.id')->label('Organization ID'),
             ])
             ->filters([
                 //

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -12,4 +12,12 @@ class Organization extends Model
     use HasFactory, HasUuids, SoftDeletes;
 
     protected $guarded = [];
+
+    /**
+     * Get the units that belong to the organization.
+     */
+    public function units()
+    {
+        return $this->hasMany(Unit::class);
+    }
 }

--- a/app/Models/Personnel.php
+++ b/app/Models/Personnel.php
@@ -13,4 +13,20 @@ class Personnel extends Model
 
     protected $table = 'personnel';
     protected $guarded = [];
+
+    /**
+     * Get the unit that this personnel belongs to.
+     */
+    public function unit()
+    {
+        return $this->belongsTo(Unit::class);
+    }
+
+    /**
+     * Get the user associated with this personnel record.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -12,4 +12,20 @@ class Unit extends Model
     use HasFactory, HasUuids, SoftDeletes;
 
     protected $guarded = [];
+
+    /**
+     * Get the organization that owns the unit.
+     */
+    public function organization()
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    /**
+     * Get the personnel assigned to the unit.
+     */
+    public function personnel()
+    {
+        return $this->hasMany(Personnel::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,4 +46,12 @@ class User extends Authenticatable implements MustVerifyEmail
         'last_name' => ['nullable' => true],
         'pesel' => ['unique' => true, 'nullable' => true],
     ];
+
+    /**
+     * Get the personnel record associated with the user.
+     */
+    public function personnel()
+    {
+        return $this->hasOne(Personnel::class);
+    }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use App\Database\Migrations\Traits\HasBlindIndexColumns;
+use App\Database\Migrations\Enums\BlindIndexType;
 
 return new class extends Migration
 {
@@ -17,10 +18,10 @@ return new class extends Migration
             $table->uuid('id')->primary();
 
           $this->addBlindIndexColumns($table, [
-                'email' => ['unique' => true],
-                'first_name' => ['nullable' => true],
-                'last_name' => ['nullable' => true],
-                'pesel' => ['unique' => true, 'nullable' => true],
+                'email' => BlindIndexType::NOT_NULL_UNIQUE,
+                'first_name' => BlindIndexType::NULLABLE,
+                'last_name' => BlindIndexType::NULLABLE,
+                'pesel' => BlindIndexType::NULLABLE_UNIQUE,
             ]);
 
             $table->timestamp('email_verified_at')->nullable();

--- a/tests/Feature/HasBlindIndexColumnsMigrationTest.php
+++ b/tests/Feature/HasBlindIndexColumnsMigrationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 use App\Database\Migrations\Traits\HasBlindIndexColumns;
+use App\Database\Migrations\Enums\BlindIndexType;
 
 class HasBlindIndexColumnsMigrationTest extends TestCase
 {
@@ -20,11 +21,13 @@ class HasBlindIndexColumnsMigrationTest extends TestCase
 
         $migration = new class {
             use HasBlindIndexColumns;
+
             public function build(Blueprint $table): void
             {
                 $this->addBlindIndexColumns($table, [
-                    'secret' => ['unique' => true],
-                    'note' => ['nullable' => true],
+                    'secret' => BlindIndexType::NOT_NULL_UNIQUE,
+                    'note' => BlindIndexType::NULLABLE,
+                    'data' => BlindIndexType::NOT_NULL,
                 ]);
             }
         };
@@ -47,10 +50,19 @@ class HasBlindIndexColumnsMigrationTest extends TestCase
         $this->assertTrue(Schema::hasColumn('temp_records', 'secret_blind_index'));
         $this->assertTrue(Schema::hasColumn('temp_records', 'note'));
         $this->assertTrue(Schema::hasColumn('temp_records', 'note_blind_index'));
+        $this->assertTrue(Schema::hasColumn('temp_records', 'data'));
+        $this->assertTrue(Schema::hasColumn('temp_records', 'data_blind_index'));
 
         DB::table('temp_records')->insert([
             'secret' => 'abc',
             'note' => null,
+            'data' => 'foo',
+        ]);
+
+        DB::table('temp_records')->insert([
+            'secret' => 'def',
+            'note' => null,
+            'data' => 'foo',
         ]);
 
         $this->expectException(QueryException::class);
@@ -58,6 +70,7 @@ class HasBlindIndexColumnsMigrationTest extends TestCase
         DB::table('temp_records')->insert([
             'secret' => 'abc',
             'note' => null,
+            'data' => 'bar',
         ]);
     }
 }

--- a/tests/Feature/ModelRelationsTest.php
+++ b/tests/Feature/ModelRelationsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\Personnel;
+use App\Models\Unit;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ModelRelationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_models_can_access_relations_via_ids()
+    {
+        $organization = Organization::create();
+        $unit = Unit::create(['organization_id' => $organization->id]);
+        $user = User::factory()->create();
+        $personnel = Personnel::create([
+            'unit_id' => $unit->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertEquals($organization->id, $unit->organization->id);
+        $this->assertTrue($organization->units->contains($unit));
+
+        $this->assertEquals($unit->id, $personnel->unit->id);
+        $this->assertTrue($unit->personnel->contains($personnel));
+
+        $this->assertEquals($user->id, $personnel->user->id);
+        $this->assertEquals($personnel->id, $user->personnel->id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `BlindIndexType` enum for specifying blind index columns
- update migration trait to accept enum values
- update user migration to use the enum
- enhance blind index migration tests to cover more cases

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*