### PR TITLE
Add enums and improve personnel models

### DIFF
--- a/app/Enums/OrganizationType.php
+++ b/app/Enums/OrganizationType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum OrganizationType: string
+{
+    case INDIVIDUAL = 'individual';
+    case GROUP_PRACTICE = 'group_practice';
+    case MEDICAL_ENTITY = 'medical_entity';
+}

--- a/app/Enums/PersonnelType.php
+++ b/app/Enums/PersonnelType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum PersonnelType: string
+{
+    case MEDICAL_DOCTOR = 'medical_doctor';
+    case DENTISTRY_DOCTOR = 'dentistry_doctor';
+    case MEDICAL_ASSISTANT = 'medical_assistant';
+}

--- a/app/Enums/UnitType.php
+++ b/app/Enums/UnitType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Enums;
+
+enum UnitType: string
+{
+    case WITHOUT_PRACTICE = 'without_practice';
+}

--- a/app/Filament/Clusters/Settings.php
+++ b/app/Filament/Clusters/Settings.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Clusters;
+
+use Filament\Clusters\Cluster;
+
+class Settings extends Cluster
+{
+    protected static ?string $navigationIcon = 'heroicon-o-squares-2x2';
+
+}

--- a/app/Filament/Pages/Auth/EmailVerificationPrompt.php
+++ b/app/Filament/Pages/Auth/EmailVerificationPrompt.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 
 class EmailVerificationPrompt extends BasePage
 {
+
     protected function sendEmailVerificationNotification(MustVerifyEmail $user): void
     {
         if ($user->hasVerifiedEmail()) {

--- a/app/Filament/Resources/OrganizationResource.php
+++ b/app/Filament/Resources/OrganizationResource.php
@@ -37,7 +37,6 @@ class OrganizationResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('id')->sortable(),
                 Tables\Columns\TextColumn::make('type')
-                    ->enum(OrganizationType::class)
                     ->sortable(),
             ])
             ->filters([

--- a/app/Filament/Resources/OrganizationResource.php
+++ b/app/Filament/Resources/OrganizationResource.php
@@ -3,20 +3,22 @@
 namespace App\Filament\Resources;
 
 use App\Enums\OrganizationType;
+use App\Filament\Clusters\Settings;
 use App\Filament\Resources\OrganizationResource\Pages;
-use App\Filament\Resources\OrganizationResource\RelationManagers;
 use App\Models\Organization;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class OrganizationResource extends Resource
 {
+    protected static ?string $cluster = Settings::class;
+
     protected static ?string $model = Organization::class;
+
+    protected static ?int $navigationSort = 1;
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
@@ -25,7 +27,7 @@ class OrganizationResource extends Resource
         return $form
             ->schema([
                 Forms\Components\Select::make('type')
-                    ->options(self::enumOptions(OrganizationType::class))
+                    ->options(OrganizationType::class)
                     ->enum(OrganizationType::class)
                     ->required(),
             ]);
@@ -68,10 +70,4 @@ class OrganizationResource extends Resource
         ];
     }
 
-    protected static function enumOptions(string $enum): array
-    {
-        return collect($enum::cases())
-            ->mapWithKeys(fn ($case) => [$case->value => str($case->name)->headline()->toString()])
-            ->all();
-    }
 }

--- a/app/Filament/Resources/OrganizationResource.php
+++ b/app/Filament/Resources/OrganizationResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\OrganizationType;
 use App\Filament\Resources\OrganizationResource\Pages;
 use App\Filament\Resources\OrganizationResource\RelationManagers;
 use App\Models\Organization;
@@ -23,7 +24,10 @@ class OrganizationResource extends Resource
     {
         return $form
             ->schema([
-                //
+                Forms\Components\Select::make('type')
+                    ->options(self::enumOptions(OrganizationType::class))
+                    ->enum(OrganizationType::class)
+                    ->required(),
             ]);
     }
 
@@ -31,7 +35,10 @@ class OrganizationResource extends Resource
     {
         return $table
             ->columns([
-                //
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('type')
+                    ->enum(OrganizationType::class)
+                    ->sortable(),
             ])
             ->filters([
                 //
@@ -60,5 +67,12 @@ class OrganizationResource extends Resource
             'create' => Pages\CreateOrganization::route('/create'),
             'edit' => Pages\EditOrganization::route('/{record}/edit'),
         ];
+    }
+
+    protected static function enumOptions(string $enum): array
+    {
+        return collect($enum::cases())
+            ->mapWithKeys(fn ($case) => [$case->value => str($case->name)->headline()->toString()])
+            ->all();
     }
 }

--- a/app/Filament/Resources/PersonnelResource.php
+++ b/app/Filament/Resources/PersonnelResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\PersonnelType;
+use App\Filament\Clusters\Settings;
 use App\Filament\Resources\PersonnelResource\Pages;
 use App\Filament\Resources\PersonnelResource\RelationManagers;
 use App\Models\Personnel;
@@ -16,7 +17,12 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class PersonnelResource extends Resource
 {
+
+    protected static ?string $cluster = Settings::class;
+
     protected static ?string $model = Personnel::class;
+
+    protected static ?int $navigationSort = 3;
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
@@ -31,7 +37,7 @@ class PersonnelResource extends Resource
                     ->relationship('user', 'id')
                     ->required(),
                 Forms\Components\Select::make('type')
-                    ->options(self::enumOptions(PersonnelType::class))
+                    ->options(PersonnelType::class)
                     ->enum(PersonnelType::class)
                     ->required(),
             ]);
@@ -76,10 +82,4 @@ class PersonnelResource extends Resource
         ];
     }
 
-    protected static function enumOptions(string $enum): array
-    {
-        return collect($enum::cases())
-            ->mapWithKeys(fn ($case) => [$case->value => str($case->name)->headline()->toString()])
-            ->all();
-    }
 }

--- a/app/Filament/Resources/PersonnelResource.php
+++ b/app/Filament/Resources/PersonnelResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\PersonnelType;
 use App\Filament\Resources\PersonnelResource\Pages;
 use App\Filament\Resources\PersonnelResource\RelationManagers;
 use App\Models\Personnel;
@@ -23,7 +24,16 @@ class PersonnelResource extends Resource
     {
         return $form
             ->schema([
-                //
+                Forms\Components\Select::make('unit_id')
+                    ->relationship('unit', 'id')
+                    ->required(),
+                Forms\Components\Select::make('user_id')
+                    ->relationship('user', 'id')
+                    ->required(),
+                Forms\Components\Select::make('type')
+                    ->options(self::enumOptions(PersonnelType::class))
+                    ->enum(PersonnelType::class)
+                    ->required(),
             ]);
     }
 
@@ -31,7 +41,12 @@ class PersonnelResource extends Resource
     {
         return $table
             ->columns([
-                //
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('unit_id')->sortable(),
+                Tables\Columns\TextColumn::make('user_id')->sortable(),
+                Tables\Columns\TextColumn::make('type')
+                    ->enum(PersonnelType::class)
+                    ->sortable(),
             ])
             ->filters([
                 //
@@ -60,5 +75,12 @@ class PersonnelResource extends Resource
             'create' => Pages\CreatePersonnel::route('/create'),
             'edit' => Pages\EditPersonnel::route('/{record}/edit'),
         ];
+    }
+
+    protected static function enumOptions(string $enum): array
+    {
+        return collect($enum::cases())
+            ->mapWithKeys(fn ($case) => [$case->value => str($case->name)->headline()->toString()])
+            ->all();
     }
 }

--- a/app/Filament/Resources/PersonnelResource.php
+++ b/app/Filament/Resources/PersonnelResource.php
@@ -45,7 +45,6 @@ class PersonnelResource extends Resource
                 Tables\Columns\TextColumn::make('unit_id')->sortable(),
                 Tables\Columns\TextColumn::make('user_id')->sortable(),
                 Tables\Columns\TextColumn::make('type')
-                    ->enum(PersonnelType::class)
                     ->sortable(),
             ])
             ->filters([

--- a/app/Filament/Resources/UnitResource.php
+++ b/app/Filament/Resources/UnitResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\UnitType;
 use App\Filament\Resources\UnitResource\Pages;
 use App\Filament\Resources\UnitResource\RelationManagers;
 use App\Models\Unit;
@@ -23,7 +24,13 @@ class UnitResource extends Resource
     {
         return $form
             ->schema([
-                //
+                Forms\Components\Select::make('organization_id')
+                    ->relationship('organization', 'id')
+                    ->required(),
+                Forms\Components\Select::make('type')
+                    ->options(self::enumOptions(UnitType::class))
+                    ->enum(UnitType::class)
+                    ->required(),
             ]);
     }
 
@@ -31,7 +38,11 @@ class UnitResource extends Resource
     {
         return $table
             ->columns([
-                //
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('organization_id')->sortable(),
+                Tables\Columns\TextColumn::make('type')
+                    ->enum(UnitType::class)
+                    ->sortable(),
             ])
             ->filters([
                 //
@@ -60,5 +71,12 @@ class UnitResource extends Resource
             'create' => Pages\CreateUnit::route('/create'),
             'edit' => Pages\EditUnit::route('/{record}/edit'),
         ];
+    }
+
+    protected static function enumOptions(string $enum): array
+    {
+        return collect($enum::cases())
+            ->mapWithKeys(fn ($case) => [$case->value => str($case->name)->headline()->toString()])
+            ->all();
     }
 }

--- a/app/Filament/Resources/UnitResource.php
+++ b/app/Filament/Resources/UnitResource.php
@@ -41,7 +41,6 @@ class UnitResource extends Resource
                 Tables\Columns\TextColumn::make('id')->sortable(),
                 Tables\Columns\TextColumn::make('organization_id')->sortable(),
                 Tables\Columns\TextColumn::make('type')
-                    ->enum(UnitType::class)
                     ->sortable(),
             ])
             ->filters([

--- a/app/Filament/Resources/UnitResource.php
+++ b/app/Filament/Resources/UnitResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\UnitType;
+use App\Filament\Clusters\Settings;
 use App\Filament\Resources\UnitResource\Pages;
 use App\Filament\Resources\UnitResource\RelationManagers;
 use App\Models\Unit;
@@ -16,7 +17,12 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class UnitResource extends Resource
 {
+
+    protected static ?string $cluster = Settings::class;
+
     protected static ?string $model = Unit::class;
+
+    protected static ?int $navigationSort = 2;
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
@@ -28,7 +34,7 @@ class UnitResource extends Resource
                     ->relationship('organization', 'id')
                     ->required(),
                 Forms\Components\Select::make('type')
-                    ->options(self::enumOptions(UnitType::class))
+                    ->options(UnitType::class)
                     ->enum(UnitType::class)
                     ->required(),
             ]);
@@ -72,10 +78,4 @@ class UnitResource extends Resource
         ];
     }
 
-    protected static function enumOptions(string $enum): array
-    {
-        return collect($enum::cases())
-            ->mapWithKeys(fn ($case) => [$case->value => str($case->name)->headline()->toString()])
-            ->all();
-    }
 }

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use App\Enums\OrganizationType;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Organization extends Model
@@ -12,4 +14,13 @@ class Organization extends Model
     use HasFactory, HasUuids, SoftDeletes;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'type' => OrganizationType::class,
+    ];
+
+    public function units(): HasMany
+    {
+        return $this->hasMany(Unit::class);
+    }
 }

--- a/app/Models/Personnel.php
+++ b/app/Models/Personnel.php
@@ -14,6 +14,7 @@ class Personnel extends Model
     use HasFactory, HasUuids, SoftDeletes;
 
     protected $table = 'personnel';
+    
     protected $guarded = [];
 
     protected $casts = [

--- a/app/Models/Personnel.php
+++ b/app/Models/Personnel.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use App\Enums\PersonnelType;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Personnel extends Model
@@ -13,4 +15,18 @@ class Personnel extends Model
 
     protected $table = 'personnel';
     protected $guarded = [];
+
+    protected $casts = [
+        'type' => PersonnelType::class,
+    ];
+
+    public function unit(): BelongsTo
+    {
+        return $this->belongsTo(Unit::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -2,9 +2,12 @@
 
 namespace App\Models;
 
+use App\Enums\UnitType;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Unit extends Model
@@ -12,4 +15,18 @@ class Unit extends Model
     use HasFactory, HasUuids, SoftDeletes;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'type' => UnitType::class,
+    ];
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function personnel(): HasMany
+    {
+        return $this->hasMany(Personnel::class);
+    }
 }

--- a/app/Providers/Filament/DoceusPanelProvider.php
+++ b/app/Providers/Filament/DoceusPanelProvider.php
@@ -6,6 +6,7 @@ use App\Filament\Pages\Auth\EditProfile;
 use App\Filament\Pages\Auth\EmailVerificationPrompt;
 use App\Filament\Pages\Auth\Register;
 use App\Filament\Pages\Auth\RequestPasswordReset;
+use Exception;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -22,24 +23,30 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 
-class AdminPanelProvider extends PanelProvider
+class DoceusPanelProvider extends PanelProvider
 {
+    /**
+     * @throws Exception
+     */
     public function panel(Panel $panel): Panel
     {
         return $panel
             ->default()
-            ->id('admin')
+            ->id('doceus')
             ->path('')
             ->passwordReset(RequestPasswordReset::class)
             ->registration(Register::class)
             ->emailVerification(EmailVerificationPrompt::class)
             ->login()
-            ->profile(EditProfile::class)
+            ->profile(EditProfile::class, false)
             ->colors([
                 'primary' => Color::Slate,
             ])
+            ->maxContentWidth('full')
+            ->topNavigation()
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
+            ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters')
             ->pages([
                 Pages\Dashboard::class,
             ])

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,7 +2,7 @@
 
 return [
     App\Providers\AppServiceProvider::class,
-    App\Providers\Filament\AdminPanelProvider::class,
+    App\Providers\Filament\DoceusPanelProvider::class,
     App\Providers\HorizonServiceProvider::class,
     App\Providers\TelescopeServiceProvider::class,
 ];

--- a/database/migrations/2025_05_27_163745_create_personnel_table.php
+++ b/database/migrations/2025_05_27_163745_create_personnel_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('personnel', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->enum('type', ['medical_doctor', 'dentistry_doctor', 'medical_assistant'])->default('medical_doctor');
+            $table->enum('type', ['medical_doctor', 'dentistry_doctor', 'medical_assistant', 'psychologist'])->default('medical_doctor');
             $table->foreignUuid('unit_id')->constrained('units', 'id');
             $table->foreignUuid('user_id')->constrained('users', 'id');
             $table->softDeletes();

--- a/tests/Feature/ModelEnumCastTest.php
+++ b/tests/Feature/ModelEnumCastTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OrganizationType;
+use App\Enums\PersonnelType;
+use App\Enums\UnitType;
+use App\Models\Organization;
+use App\Models\Personnel;
+use App\Models\Unit;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ModelEnumCastTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_types_are_cast_to_enums()
+    {
+        $org = Organization::create([
+            'type' => OrganizationType::MEDICAL_ENTITY,
+        ]);
+
+        $this->assertInstanceOf(OrganizationType::class, $org->type);
+        $this->assertSame(OrganizationType::MEDICAL_ENTITY, $org->fresh()->type);
+
+        $unit = Unit::create([
+            'organization_id' => $org->id,
+            'type' => UnitType::WITHOUT_PRACTICE,
+        ]);
+
+        $this->assertInstanceOf(UnitType::class, $unit->type);
+        $this->assertSame(UnitType::WITHOUT_PRACTICE, $unit->fresh()->type);
+
+        $user = User::factory()->create();
+
+        $personnel = Personnel::create([
+            'unit_id' => $unit->id,
+            'user_id' => $user->id,
+            'type' => PersonnelType::MEDICAL_ASSISTANT,
+        ]);
+
+        $this->assertInstanceOf(PersonnelType::class, $personnel->type);
+        $this->assertSame(PersonnelType::MEDICAL_ASSISTANT, $personnel->fresh()->type);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `OrganizationType`, `UnitType`, and `PersonnelType` enums
- use enums and add relationships in organization, unit, and personnel models
- build out Filament resources with enum selects and table columns
- test that enums are correctly cast on the models

## Testing
- `php artisan test` *(fails: `php: command not found`)*