### PR TITLE
Add role translation and label test

### DIFF
--- a/lang/en/doceus.php
+++ b/lang/en/doceus.php
@@ -7,6 +7,10 @@ return [
         'email' => 'Email',
         'language' => 'Language',
     ],
+    'auth' => [
+        'first_name' => 'First Name',
+        'last_name' => 'Last Name',
+    ],
     'organization' => [
         'type' => 'Organization Type',
         'individual' => 'Individual',
@@ -27,6 +31,8 @@ return [
         'is_psychotherapist' => 'Psychotherapist',
         'has_registered_practice' => 'Has registered practice',
         'is_healthcare_manager' => 'Healthcare manager',
+        'is_superadmin' => 'Super administrator',
+        'is_admin' => 'Administrator',
     ],
     'language' => [
         'en' => 'English',

--- a/lang/pl/doceus.php
+++ b/lang/pl/doceus.php
@@ -7,6 +7,10 @@ return [
         'email' => 'Email',
         'language' => 'Język',
     ],
+    'auth' => [
+        'first_name' => 'Imię',
+        'last_name' => 'Nazwisko',
+    ],
     'organization' => [
         'type' => 'Typ organizacji',
         'individual' => 'Osoba indywidualna',
@@ -27,6 +31,8 @@ return [
         'is_psychotherapist' => 'Psychoterapeuta',
         'has_registered_practice' => 'Posiada zarejestrowaną praktykę',
         'is_healthcare_manager' => 'Menedżer ochrony zdrowia',
+        'is_superadmin' => 'Superadministrator',
+        'is_admin' => 'Administrator',
     ],
     'language' => [
         'en' => 'Angielski',

--- a/tests/Feature/RoleTypeLabelTest.php
+++ b/tests/Feature/RoleTypeLabelTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\RoleType;
+use Tests\TestCase;
+
+class RoleTypeLabelTest extends TestCase
+{
+    public function test_label_returns_translated_value(): void
+    {
+        app()->setLocale('en');
+
+        $this->assertSame('Super administrator', RoleType::IS_SUPERADMIN->label());
+        $this->assertSame('Administrator', RoleType::IS_ADMIN->label());
+    }
+}


### PR DESCRIPTION
## Summary
- add missing `auth` key to language files
- translate role constants `is_superadmin` and `is_admin`
- test that role labels resolve to translations

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*