### PR TITLE
Rename RoleType to UserFeature

### DIFF
--- a/app/Enums/UserFeature.php
+++ b/app/Enums/UserFeature.php
@@ -4,7 +4,7 @@ namespace App\Enums;
 
 use App\Enums\Traits\HasTranslatableLabel;
 
-enum RoleType: string
+enum UserFeature: string
 {
     use HasTranslatableLabel;
 
@@ -32,6 +32,6 @@ enum RoleType: string
 
     protected function translationPrefix(): string
     {
-        return 'doceus.role';
+        return 'doceus.feature';
     }
 }

--- a/app/Filament/Pages/Tenancy/RegisterOrganization.php
+++ b/app/Filament/Pages/Tenancy/RegisterOrganization.php
@@ -3,9 +3,8 @@
 namespace App\Filament\Pages\Tenancy;
 
 use App\Enums\OrganizationType;
-use App\Enums\RoleType;
+use App\Enums\UserFeature;
 use App\Models\Organization;
-use App\Models\Role;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Pages\Tenancy\RegisterTenant;
@@ -30,13 +29,13 @@ class RegisterOrganization extends RegisterTenant
                     )
                     ->enum(OrganizationType::class)
                     ->required(),
-                Select::make('role_type')
+                Select::make('feature')
                     ->options(
-                        collect(RoleType::cases())->mapWithKeys(
+                        collect(UserFeature::cases())->mapWithKeys(
                             fn ($case) => [$case->value => $case->label()]
                         )->toArray()
                     )
-                    ->enum(RoleType::class)
+                    ->enum(UserFeature::class)
                     ->required(),
             ]);
     }
@@ -53,13 +52,13 @@ class RegisterOrganization extends RegisterTenant
 
             // 2. Attach user to organization with role
             $organization->users()->attach($user->id, [
-                'role_type' => $data['role_type'],
+                'feature' => $data['feature'],
             ]);
 
             // 3. Optionally: Set user's default org/role
             $user->update([
                 'default_organization_id' => $organization->id,
-                // To reference default role, use org_id+user_id+role_type, or just role_type if user/org is unique
+                // To reference default feature, use org_id+user_id+feature, or just feature if user/org is unique
             ]);
 
             return $organization;

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -28,7 +28,7 @@ class Organization extends Model
     {
         return $this->belongsToMany(User::class)
             ->using(OrganizationUser::class)
-            ->withPivot('role_type');
+            ->withPivot('feature');
     }
 
 }

--- a/database/migrations/2025_05_29_011217_create_organization_user_table.php
+++ b/database/migrations/2025_05_29_011217_create_organization_user_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Enums\RoleType;
+use App\Enums\UserFeature;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,8 +15,8 @@ return new class extends Migration
         Schema::create('organization_user', function (Blueprint $table) {
             $table->uuid('organization_id');
             $table->uuid('user_id');
-            $table->enum('role_type', array_column(RoleType::cases(), 'value'));
-            $table->primary(['organization_id', 'user_id', 'role_type']);
+            $table->enum('feature', array_column(UserFeature::cases(), 'value'));
+            $table->primary(['organization_id', 'user_id', 'feature']);
 
             $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();

--- a/lang/en/doceus.php
+++ b/lang/en/doceus.php
@@ -19,7 +19,7 @@ return [
         'label' => 'Organization',
         'plural_label' => 'Organizations',
     ],
-    'role' => [
+    'feature' => [
         'is_medical_doctor' => 'Medical doctor',
         'is_medical_assistant' => 'Medical assistant',
         'is_dentistry_doctor' => 'Dentistry doctor',
@@ -34,6 +34,8 @@ return [
         'is_healthcare_manager' => 'Healthcare manager',
         'is_superadmin' => 'Super administrator',
         'is_admin' => 'Administrator',
+        'is_owner' => 'Owner',
+        'is_user' => 'User',
     ],
     'language' => [
         'en' => 'English',

--- a/lang/pl/doceus.php
+++ b/lang/pl/doceus.php
@@ -19,7 +19,7 @@ return [
         'label' => 'Organizacja',
         'plural_label' => 'Organizacje',
     ],
-    'role' => [
+    'feature' => [
         'is_medical_doctor' => 'Lekarz',
         'is_medical_assistant' => 'Asystent medyczny',
         'is_dentistry_doctor' => 'Dentysta',
@@ -34,6 +34,8 @@ return [
         'is_healthcare_manager' => 'Menedżer ochrony zdrowia',
         'is_superadmin' => 'Superadministrator',
         'is_admin' => 'Administrator',
+        'is_owner' => 'Właściciel',
+        'is_user' => 'Użytkownik',
     ],
     'language' => [
         'en' => 'Angielski',


### PR DESCRIPTION
## Summary
- rename `RoleType` enum to `UserFeature`
- update models, migrations, and Filament page with new `feature` column
- rename translation group from `role` to `feature`
- add missing translations for `is_owner` and `is_user`

## Testing
- `composer test` *(fails: composer not found)*