### PR TITLE
Improve translation groups and PESEL rule

### DIFF
--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -3,6 +3,9 @@
 namespace App\Models;
 
 use App\Enums\OrganizationType;
+use App\Models\OrganizationFeature;
+use App\Models\OrganizationUserFeature;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -26,9 +29,17 @@ class Organization extends Model
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class)
+        return $this->belongsToMany(
+            User::class,
+            'organization_user_features'
+        )
             ->using(OrganizationUserFeature::class)
-            ->withPivot('feature');
+            ->withPivot(['feature', 'event', 'created_at', 'created_by']);
+    }
+
+    public function features(): HasMany
+    {
+        return $this->hasMany(OrganizationFeature::class);
     }
 
 }

--- a/app/Models/OrganizationFeature.php
+++ b/app/Models/OrganizationFeature.php
@@ -2,11 +2,35 @@
 
 namespace App\Models;
 
+use App\Enums\FeatureEvent;
+use App\Enums\OrganizationFeature as OrganizationFeatureEnum;
+use App\Models\Organization;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class OrganizationFeature extends Model
 {
     use HasFactory, HasUuids;
+
+    protected $table = 'organization_features';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'feature' => OrganizationFeatureEnum::class,
+        'event' => FeatureEvent::class,
+    ];
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
 }

--- a/app/Models/OrganizationUserFeature.php
+++ b/app/Models/OrganizationUserFeature.php
@@ -2,11 +2,42 @@
 
 namespace App\Models;
 
+use App\Enums\FeatureEvent;
+use App\Enums\UserFeature;
+use App\Models\Organization;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
-class OrganizationUserFeature extends Model
+class OrganizationUserFeature extends Pivot
 {
     use HasFactory, HasUuids;
+
+    protected $table = 'organization_user_features';
+
+    protected $guarded = [];
+
+    public $incrementing = false;
+
+    protected $casts = [
+        'feature' => UserFeature::class,
+        'event' => FeatureEvent::class,
+    ];
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Organization;
+use App\Models\OrganizationUserFeature;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
@@ -68,8 +70,12 @@ class User extends Authenticatable implements FilamentUser, HasTenants, MustVeri
 
     public function organizations(): BelongsToMany
     {
-        return $this->belongsToMany(Organization::class)
-            ->using(OrganizationUser::class);
+        return $this->belongsToMany(
+            Organization::class,
+            'organization_user_features'
+        )
+            ->using(OrganizationUserFeature::class)
+            ->withPivot(['feature', 'event', 'created_at', 'created_by']);
     }
 
     public function getTenants(Panel $panel): Collection

--- a/app/Rules/ValidPesel.php
+++ b/app/Rules/ValidPesel.php
@@ -10,7 +10,7 @@ class ValidPesel implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! preg_match('/^\d{11}$/', $value)) {
-            $fail(__('doceus.pesel-exact-eleven-digits'));
+            $fail(__('doceus.pesel.exact-eleven-digits'));
 
             return;
         }
@@ -21,7 +21,7 @@ class ValidPesel implements ValidationRule
         }
         $control = (10 - ($sum % 10)) % 10;
         if ($control !== (int) $value[10]) {
-            $fail(__('doceus.pesel-invalid'));
+            $fail(__('doceus.pesel.invalid'));
         }
     }
 }

--- a/database/migrations/2025_05_27_163733_create_organizations_table.php
+++ b/database/migrations/2025_05_27_163733_create_organizations_table.php
@@ -3,6 +3,7 @@
 use App\Enums\OrganizationType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('organizations', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->enum('type', array_column(OrganizationType::cases(), 'value'));
+            $table->enum('type', Arr::pluck(OrganizationType::cases(), 'value'));
             $table->timestamps();
         });
     }

--- a/lang/en/doceus.php
+++ b/lang/en/doceus.php
@@ -13,11 +13,13 @@ return [
         'pesel' => 'PESEL',
     ],
     'organization' => [
-        'type' => 'Organization Type',
-        'individual' => 'Individual',
-        'entity' => 'Entity',
         'label' => 'Organization',
         'plural_label' => 'Organizations',
+    ],
+    'organization_type' => [
+        'label' => 'Organization Type',
+        'individual' => 'Individual',
+        'entity' => 'Entity',
     ],
     'user_feature' => [
         'is_medical_doctor' => 'Medical doctor',
@@ -37,11 +39,25 @@ return [
         'is_owner' => 'Owner',
         'is_user' => 'User',
     ],
+    'organization_feature' => [
+        'is_registered_practice' => 'Registered practice',
+        'is_specialized_practice' => 'Specialized medical practice',
+        'is_medical_practice' => 'Medical practice',
+        'is_dental_practice' => 'Dental practice',
+        'is_group_medical_practice' => 'Group medical practice',
+        'is_medical_facility' => 'Medical facility',
+    ],
+    'feature_event' => [
+        'granted' => 'Granted',
+        'revoked' => 'Revoked',
+    ],
     'language' => [
         'en' => 'English',
         'pl' => 'Polish',
     ],
-    'pesel-exact-eleven-digits' => 'The PESEL must be exactly 11 digits.',
-    'pesel-invalid' => 'The PESEL number is invalid.',
+    'pesel' => [
+        'exact-eleven-digits' => 'The PESEL must be exactly 11 digits.',
+        'invalid' => 'The PESEL number is invalid.',
+    ],
     'settings' => 'Settings',
 ];

--- a/lang/pl/doceus.php
+++ b/lang/pl/doceus.php
@@ -13,11 +13,13 @@ return [
         'pesel' => 'PESEL',
     ],
     'organization' => [
-        'type' => 'Typ organizacji',
-        'individual' => 'Osoba indywidualna',
-        'entity' => 'Jednostka',
         'label' => 'Organizacja',
         'plural_label' => 'Organizacje',
+    ],
+    'organization_type' => [
+        'label' => 'Typ organizacji',
+        'individual' => 'Osoba indywidualna',
+        'entity' => 'Jednostka',
     ],
     'user_feature' => [
         'is_medical_doctor' => 'Lekarz',
@@ -37,11 +39,25 @@ return [
         'is_owner' => 'Właściciel',
         'is_user' => 'Użytkownik',
     ],
+    'organization_feature' => [
+        'is_registered_practice' => 'Zarejestrowana praktyka',
+        'is_specialized_practice' => 'Specjalistyczna praktyka medyczna',
+        'is_medical_practice' => 'Praktyka lekarska',
+        'is_dental_practice' => 'Praktyka dentystyczna',
+        'is_group_medical_practice' => 'Grupowa praktyka lekarska',
+        'is_medical_facility' => 'Placówka medyczna',
+    ],
+    'feature_event' => [
+        'granted' => 'Przyznano',
+        'revoked' => 'Cofnięto',
+    ],
     'language' => [
         'en' => 'Angielski',
         'pl' => 'Polski',
     ],
-    'pesel-exact-eleven-digits' => 'PESEL musi składać się dokładnie z 11 cyfr.',
-    'pesel-invalid' => 'Niepoprawny numer PESEL.',
+    'pesel' => [
+        'exact-eleven-digits' => 'PESEL musi składać się dokładnie z 11 cyfr.',
+        'invalid' => 'Niepoprawny numer PESEL.',
+    ],
     'settings' => 'Ustawienia',
 ];


### PR DESCRIPTION
## Summary
- group all translation keys into logical namespaces
- add translations for organization features and feature events
- update PESEL validation rule to use new translation keys

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*