### PR TITLE
Add organization users materialized view

### DIFF
--- a/app/Events/MaterializedViewNeedsRefresh.php
+++ b/app/Events/MaterializedViewNeedsRefresh.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Events;
+
+class MaterializedViewNeedsRefresh
+{
+    public function __construct(
+        public string $viewName,
+        public bool $concurrently = false,
+    ) {
+    }
+}

--- a/app/Listeners/RefreshMaterializedView.php
+++ b/app/Listeners/RefreshMaterializedView.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\MaterializedViewNeedsRefresh;
+use App\Support\MaterializedView;
+
+class RefreshMaterializedView
+{
+    public function handle(MaterializedViewNeedsRefresh $event): void
+    {
+        MaterializedView::refresh($event->viewName, $event->concurrently);
+    }
+}

--- a/app/Models/OrganizationUser.php
+++ b/app/Models/OrganizationUser.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OrganizationUser extends Model
+{
+    protected $table = 'organization_users';
+
+    protected $guarded = [];
+
+    public $incrementing = false;
+
+    public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::saving(fn() => false);
+        static::creating(fn() => false);
+        static::updating(fn() => false);
+        static::deleting(fn() => false);
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/OrganizationUserFeature.php
+++ b/app/Models/OrganizationUserFeature.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\FeatureEvent;
 use App\Enums\UserFeature;
+use App\Events\MaterializedViewNeedsRefresh;
 use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -21,6 +22,13 @@ class OrganizationUserFeature extends Model
     protected $guarded = [];
 
     public $incrementing = false;
+
+    protected static function booted(): void
+    {
+        static::created(function (): void {
+            event(new MaterializedViewNeedsRefresh('organization_users'));
+        });
+    }
 
     protected $casts = [
         'feature' => UserFeature::class,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,10 @@
 namespace App\Providers;
 
 use App\Auth\BlindIndexUserProvider;
+use App\Events\MaterializedViewNeedsRefresh;
+use App\Listeners\RefreshMaterializedView;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -31,6 +34,11 @@ class AppServiceProvider extends ServiceProvider
         Auth::provider('blindindex', function ($app, array $config) {
             return new BlindIndexUserProvider($app['hash'], $config['model']);
         });
+
+        Event::listen(
+            MaterializedViewNeedsRefresh::class,
+            RefreshMaterializedView::class,
+        );
 
     }
 }

--- a/app/Support/MaterializedView.php
+++ b/app/Support/MaterializedView.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\DB;
+
+class MaterializedView
+{
+    public static function create(string $name, string $query): void
+    {
+        DB::statement("CREATE MATERIALIZED VIEW {$name} AS {$query}");
+    }
+
+    public static function drop(string $name): void
+    {
+        DB::statement("DROP MATERIALIZED VIEW IF EXISTS {$name} CASCADE");
+    }
+
+    public static function refresh(string $name, bool $concurrently = false): void
+    {
+        $concurrent = $concurrently ? 'CONCURRENTLY ' : '';
+        DB::statement("REFRESH MATERIALIZED VIEW {$concurrent}{$name}");
+    }
+}

--- a/database/migrations/2025_05_31_000000_create_organization_users_view.php
+++ b/database/migrations/2025_05_31_000000_create_organization_users_view.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Support\MaterializedView;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        MaterializedView::create('organization_users', '
+            SELECT DISTINCT organization_id, user_id
+            FROM organization_user_features
+        ');
+
+        DB::statement('CREATE UNIQUE INDEX organization_users_pk ON organization_users (organization_id, user_id)');
+    }
+
+    public function down(): void
+    {
+        MaterializedView::drop('organization_users');
+    }
+};


### PR DESCRIPTION
## Summary
- implement MaterializedView helper for PostgreSQL views
- add MaterializedViewNeedsRefresh event and RefreshMaterializedView listener
- dispatch event from OrganizationUserFeature model
- create read-only OrganizationUser pivot model
- create migration for organization_users materialized view
- register event listener in AppServiceProvider

## Testing
- `composer test` *(fails: composer not found)*