### PR TITLE
Add unique organization relations

### DIFF
--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\OrganizationType;
 use App\Models\OrganizationFeature;
+use App\Models\OrganizationUser;
 use App\Models\OrganizationUserFeature;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -35,6 +36,14 @@ class Organization extends Model
         )
             ->using(OrganizationUserFeature::class)
             ->withPivot(['feature', 'event', 'created_at', 'created_by']);
+    }
+
+    public function uniqueUsers(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            User::class,
+            'organization_users'
+        )->using(OrganizationUser::class);
     }
 
     public function features(): HasMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\Organization;
+use App\Models\OrganizationUser;
 use App\Models\OrganizationUserFeature;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -78,14 +79,22 @@ class User extends Authenticatable implements FilamentUser, HasTenants, MustVeri
             ->withPivot(['feature', 'event', 'created_at', 'created_by']);
     }
 
+    public function uniqueOrganizations(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Organization::class,
+            'organization_users'
+        )->using(OrganizationUser::class);
+    }
+
     public function getTenants(Panel $panel): Collection
     {
-        return $this->organizations()->get()->unique();
+        return $this->uniqueOrganizations()->get();
     }
 
     public function canAccessTenant(Model $tenant): bool
     {
-        return $this->organizations()->whereKey($tenant)->exists();
+        return $this->uniqueOrganizations()->whereKey($tenant)->exists();
     }
 
     public function canAccessPanel(Panel $panel): bool


### PR DESCRIPTION
## Summary
- join users with organizations via the `organization_users` materialized view
- expose `uniqueOrganizations()` on `User`
- expose `uniqueUsers()` on `Organization`
- use new relation in tenant access checks

## Testing
- `composer test` *(fails: composer not installed)*