### PR TITLE
feat: introduce blind index migration utility

### DIFF
--- a/app/Database/BlindIndexes/BlindIndex.php
+++ b/app/Database/BlindIndexes/BlindIndex.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Database\BlindIndexes;
+
+use Illuminate\Database\Schema\Blueprint;
+
+class BlindIndex
+{
+    protected Blueprint $table;
+
+    public static function table(Blueprint $table): static
+    {
+        $instance = new static();
+        $instance->table = $table;
+
+        return $instance;
+    }
+
+    /**
+     * Add blind index columns to the table.
+     */
+    public function columns(array $columns): void
+    {
+        foreach ($columns as $column => $options) {
+            $unique = false;
+            $nullable = false;
+
+            if (is_bool($options)) {
+                $unique = $options;
+            } elseif (is_array($options)) {
+                $unique = $options['unique'] ?? false;
+                $nullable = $options['nullable'] ?? false;
+            }
+
+            $textColumn = $this->table->text($column);
+            if ($nullable) {
+                $textColumn->nullable()->default(null);
+            }
+
+            $indexColumn = $this->table->char($column . '_blind_index', 64)->default('');
+            if ($nullable) {
+                $indexColumn->nullable()->default(null);
+            }
+
+            if ($unique) {
+                $indexColumn->unique();
+            } else {
+                $indexColumn->index();
+            }
+        }
+    }
+}

--- a/app/Database/Migrations/Traits/HasBlindIndexColumns.php
+++ b/app/Database/Migrations/Traits/HasBlindIndexColumns.php
@@ -2,38 +2,13 @@
 
 namespace App\Database\Migrations\Traits;
 
+use App\Database\BlindIndexes\BlindIndex;
 use Illuminate\Database\Schema\Blueprint;
 
 trait HasBlindIndexColumns
 {
     protected function addBlindIndexColumns(Blueprint $table, array $columns): void
     {
-        foreach ($columns as $column => $options) {
-            $unique = false;
-            $nullable = false;
-
-            if (is_bool($options)) {
-                $unique = $options;
-            } elseif (is_array($options)) {
-                $unique = $options['unique'] ?? false;
-                $nullable = $options['nullable'] ?? false;
-            }
-
-            $textColumn = $table->text($column);
-            if ($nullable) {
-                $textColumn->nullable()->default(null);
-            }
-
-            $indexColumn = $table->char($column.'_blind_index', 64)->default('');
-            if ($nullable) {
-                $indexColumn->nullable()->default(null);
-            }
-
-            if ($unique) {
-                $indexColumn->unique();
-            } else {
-                $indexColumn->index();
-            }
-        }
+        BlindIndex::table($table)->columns($columns);
     }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -1,14 +1,12 @@
 <?php
 
-use App\Database\Migrations\Traits\HasBlindIndexColumns;
+use App\Database\BlindIndexes\BlindIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    use HasBlindIndexColumns;
-
     /**
      * Run the migrations.
      */
@@ -17,7 +15,7 @@ return new class extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->uuid('id')->primary();
 
-            $this->addBlindIndexColumns($table, [
+            BlindIndex::table($table)->columns([
                 'email' => ['unique' => true],
                 'first_name' => ['nullable' => true],
                 'last_name' => ['nullable' => true],

--- a/tests/Feature/BlindIndexColumnsUtilityTest.php
+++ b/tests/Feature/BlindIndexColumnsUtilityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Database\BlindIndexes\BlindIndex;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class BlindIndexColumnsUtilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('utility_records', function (Blueprint $table) {
+            $table->increments('id');
+            BlindIndex::table($table)->columns([
+                'secret' => ['unique' => true],
+            ]);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('utility_records');
+        parent::tearDown();
+    }
+
+    public function test_columns_are_added_using_utility(): void
+    {
+        $this->assertTrue(Schema::hasColumn('utility_records', 'secret'));
+        $this->assertTrue(Schema::hasColumn('utility_records', 'secret_blind_index'));
+    }
+}


### PR DESCRIPTION
## Summary
- add BlindIndex builder for migrations
- refactor migration trait to use the builder
- update users migration to use BlindIndex builder
- test utility works in migrations

## Testing
- `phpunit` *(fails: `phpunit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6839f8d125e08328ae3ebf39ae7f0703