### PR TITLE
feat: introduce fluent blind index builder

### DIFF
--- a/app/Database/BlindIndexes/BlindIndex.php
+++ b/app/Database/BlindIndexes/BlindIndex.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Database\BlindIndexes;
+
+use Illuminate\Database\Schema\Blueprint;
+
+class BlindIndex
+{
+    protected Blueprint $table;
+
+    public static function table(Blueprint $table): static
+    {
+        $instance = new static();
+        $instance->table = $table;
+
+        return $instance;
+    }
+
+    public function column(string $name): BlindIndexColumn
+    {
+        return new BlindIndexColumn($this->table, $name);
+    }
+
+    /**
+     * Convenience method to add multiple columns at once.
+     *
+     * @param array<string, array|bool> $columns
+     */
+    public function columns(array $columns): void
+    {
+        foreach ($columns as $column => $options) {
+            $builder = $this->column($column);
+
+            if (is_bool($options)) {
+                if ($options) {
+                    $builder->unique();
+                }
+            } elseif (is_array($options)) {
+                if (($options['unique'] ?? false) === true) {
+                    $builder->unique();
+                }
+                if (($options['nullable'] ?? false) === true) {
+                    $builder->nullable();
+                }
+            }
+
+            $builder->apply();
+        }
+    }
+}
+
+class BlindIndexColumn
+{
+    protected bool $unique = false;
+    protected bool $nullable = false;
+    protected bool $applied = false;
+
+    public function __construct(protected Blueprint $table, protected string $name)
+    {
+    }
+
+    public function unique(bool $value = true): static
+    {
+        $this->unique = $value;
+        return $this;
+    }
+
+    public function nullable(bool $value = true): static
+    {
+        $this->nullable = $value;
+        return $this;
+    }
+
+    public function apply(): void
+    {
+        if ($this->applied) {
+            return;
+        }
+
+        $textColumn = $this->table->text($this->name);
+        if ($this->nullable) {
+            $textColumn->nullable()->default(null);
+        }
+
+        $indexColumn = $this->table->char($this->name . '_blind_index', 64)->default('');
+        if ($this->nullable) {
+            $indexColumn->nullable()->default(null);
+        }
+
+        if ($this->unique) {
+            $indexColumn->unique();
+        } else {
+            $indexColumn->index();
+        }
+
+        $this->applied = true;
+    }
+
+    public function __destruct()
+    {
+        $this->apply();
+    }
+}

--- a/app/Database/BlindIndexes/BlindIndex.php
+++ b/app/Database/BlindIndexes/BlindIndex.php
@@ -16,25 +16,19 @@ class BlindIndex
         return $instance;
     }
 
-<<<<<<< HEAD
     public function column(string $name): BlindIndexColumn
     {
         return new BlindIndexColumn($this->table, $name);
     }
 
     /**
-     * Convenience method to add multiple columns at once.
-     *
+     * Add blind index columns to the table (multiple at once).
      * @param array<string, array|bool> $columns
-=======
-    /**
-     * Add blind index columns to the table.
->>>>>>> feat/redesign-features
      */
     public function columns(array $columns): void
     {
         foreach ($columns as $column => $options) {
-<<<<<<< HEAD
+            // Use builder so custom logic (unique/nullable/apply) works
             $builder = $this->column($column);
 
             if (is_bool($options)) {
@@ -107,33 +101,3 @@ class BlindIndexColumn
         $this->apply();
     }
 }
-=======
-            $unique = false;
-            $nullable = false;
-
-            if (is_bool($options)) {
-                $unique = $options;
-            } elseif (is_array($options)) {
-                $unique = $options['unique'] ?? false;
-                $nullable = $options['nullable'] ?? false;
-            }
-
-            $textColumn = $this->table->text($column);
-            if ($nullable) {
-                $textColumn->nullable()->default(null);
-            }
-
-            $indexColumn = $this->table->char($column . '_blind_index', 64)->default('');
-            if ($nullable) {
-                $indexColumn->nullable()->default(null);
-            }
-
-            if ($unique) {
-                $indexColumn->unique();
-            } else {
-                $indexColumn->index();
-            }
-        }
-    }
-}
->>>>>>> feat/redesign-features

--- a/app/Database/Migrations/Traits/HasBlindIndexColumns.php
+++ b/app/Database/Migrations/Traits/HasBlindIndexColumns.php
@@ -2,38 +2,13 @@
 
 namespace App\Database\Migrations\Traits;
 
+use App\Database\BlindIndexes\BlindIndex;
 use Illuminate\Database\Schema\Blueprint;
 
 trait HasBlindIndexColumns
 {
     protected function addBlindIndexColumns(Blueprint $table, array $columns): void
     {
-        foreach ($columns as $column => $options) {
-            $unique = false;
-            $nullable = false;
-
-            if (is_bool($options)) {
-                $unique = $options;
-            } elseif (is_array($options)) {
-                $unique = $options['unique'] ?? false;
-                $nullable = $options['nullable'] ?? false;
-            }
-
-            $textColumn = $table->text($column);
-            if ($nullable) {
-                $textColumn->nullable()->default(null);
-            }
-
-            $indexColumn = $table->char($column.'_blind_index', 64)->default('');
-            if ($nullable) {
-                $indexColumn->nullable()->default(null);
-            }
-
-            if ($unique) {
-                $indexColumn->unique();
-            } else {
-                $indexColumn->index();
-            }
-        }
+        BlindIndex::table($table)->columns($columns);
     }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -1,14 +1,12 @@
 <?php
 
-use App\Database\Migrations\Traits\HasBlindIndexColumns;
+use App\Database\BlindIndexes\BlindIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    use HasBlindIndexColumns;
-
     /**
      * Run the migrations.
      */
@@ -17,12 +15,11 @@ return new class extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->uuid('id')->primary();
 
-            $this->addBlindIndexColumns($table, [
-                'email' => ['unique' => true],
-                'first_name' => ['nullable' => true],
-                'last_name' => ['nullable' => true],
-                'pesel' => ['unique' => true, 'nullable' => true],
-            ]);
+            $blind = BlindIndex::table($table);
+            $blind->column('email')->unique()->apply();
+            $blind->column('first_name')->nullable()->apply();
+            $blind->column('last_name')->nullable()->apply();
+            $blind->column('pesel')->unique()->nullable()->apply();
 
             $table->enum('language', ['en', 'pl'])->nullable();
 

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,23 +15,22 @@ return new class extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->uuid('id')->primary();
 
-<<<<<<< HEAD
-            $blind = BlindIndex::table($table);
-            $blind->column('email')->unique()->apply();
-            $blind->column('first_name')->nullable()->apply();
-            $blind->column('last_name')->nullable()->apply();
-            $blind->column('pesel')->unique()->nullable()->apply();
-=======
+            // Recommended concise style
             BlindIndex::table($table)->columns([
-                'email' => ['unique' => true],
+                'email'      => ['unique' => true],
                 'first_name' => ['nullable' => true],
-                'last_name' => ['nullable' => true],
-                'pesel' => ['unique' => true, 'nullable' => true],
+                'last_name'  => ['nullable' => true],
+                'pesel'      => ['unique' => true, 'nullable' => true],
             ]);
->>>>>>> feat/redesign-features
+
+            // Or (less concise, but also valid):
+            // $blind = BlindIndex::table($table);
+            // $blind->column('email')->unique()->apply();
+            // $blind->column('first_name')->nullable()->apply();
+            // $blind->column('last_name')->nullable()->apply();
+            // $blind->column('pesel')->unique()->nullable()->apply();
 
             $table->enum('language', ['en', 'pl'])->nullable();
-
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
@@ -43,7 +42,6 @@ return new class extends Migration
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });
-
     }
 
     /**

--- a/tests/Feature/BlindIndexColumnsUtilityTest.php
+++ b/tests/Feature/BlindIndexColumnsUtilityTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Database\BlindIndexes\BlindIndex;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class BlindIndexColumnsUtilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('utility_records', function (Blueprint $table) {
+            $table->increments('id');
+            BlindIndex::table($table)
+                ->column('secret')
+                ->unique()
+                ->apply();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('utility_records');
+        parent::tearDown();
+    }
+
+    public function test_columns_are_added_using_utility(): void
+    {
+        $this->assertTrue(Schema::hasColumn('utility_records', 'secret'));
+        $this->assertTrue(Schema::hasColumn('utility_records', 'secret_blind_index'));
+    }
+}

--- a/tests/Feature/BlindIndexColumnsUtilityTest.php
+++ b/tests/Feature/BlindIndexColumnsUtilityTest.php
@@ -18,16 +18,16 @@ class BlindIndexColumnsUtilityTest extends TestCase
 
         Schema::create('utility_records', function (Blueprint $table) {
             $table->increments('id');
-<<<<<<< HEAD
-            BlindIndex::table($table)
-                ->column('secret')
-                ->unique()
-                ->apply();
-=======
+            // Preferred concise style:
             BlindIndex::table($table)->columns([
                 'secret' => ['unique' => true],
             ]);
->>>>>>> feat/redesign-features
+
+            // Or, for single columns (alternative):
+            // BlindIndex::table($table)
+            //     ->column('secret')
+            //     ->unique()
+            //     ->apply();
         });
     }
 


### PR DESCRIPTION
## Summary
- redesign blind index builder to expose a fluent API
- adjust users migration to use fluent builder
- update tests to demonstrate new builder

## Testing
- `phpunit` *(fails: `phpunit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6839f8d125e08328ae3ebf39ae7f0703