### PR TITLE
Implement fluent blind index columns

### DIFF
--- a/app/Database/BlindIndexes/BlindIndex.php
+++ b/app/Database/BlindIndexes/BlindIndex.php
@@ -4,6 +4,10 @@ namespace App\Database\BlindIndexes;
 
 use Illuminate\Database\Schema\Blueprint;
 
+/**
+ * Utility for managing blind index columns on a table.
+ */
+
 class BlindIndex
 {
     protected Blueprint $table;
@@ -17,36 +21,34 @@ class BlindIndex
     }
 
     /**
-     * Add blind index columns to the table.
+     * Add blind index columns using the legacy array syntax.
      */
     public function columns(array $columns): void
     {
         foreach ($columns as $column => $options) {
-            $unique = false;
-            $nullable = false;
+            $definition = $this->create($column);
 
-            if (is_bool($options)) {
-                $unique = $options;
-            } elseif (is_array($options)) {
-                $unique = $options['unique'] ?? false;
-                $nullable = $options['nullable'] ?? false;
+            if (is_bool($options) && $options) {
+                $definition->unique();
             }
 
-            $textColumn = $this->table->text($column);
-            if ($nullable) {
-                $textColumn->nullable()->default(null);
-            }
+            if (is_array($options)) {
+                if (($options['unique'] ?? false) === true) {
+                    $definition->unique();
+                }
 
-            $indexColumn = $this->table->char($column . '_blind_index', 64)->default('');
-            if ($nullable) {
-                $indexColumn->nullable()->default(null);
-            }
-
-            if ($unique) {
-                $indexColumn->unique();
-            } else {
-                $indexColumn->index();
+                if (($options['nullable'] ?? false) === true) {
+                    $definition->nullable();
+                }
             }
         }
+    }
+
+    /**
+     * Create a new blind index column definition.
+     */
+    public function create(string $column): BlindIndexColumn
+    {
+        return new BlindIndexColumn($this->table, $column);
     }
 }

--- a/app/Database/BlindIndexes/BlindIndexColumn.php
+++ b/app/Database/BlindIndexes/BlindIndexColumn.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Database\BlindIndexes;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
+
+class BlindIndexColumn
+{
+    protected ColumnDefinition $textColumn;
+    protected ColumnDefinition $indexColumn;
+    protected bool $unique = false;
+
+    public function __construct(protected Blueprint $table, protected string $name)
+    {
+        $this->textColumn = $this->table->text($this->name);
+        $this->indexColumn = $this->table->char($this->name . '_blind_index', 64)->default('');
+    }
+
+    /**
+     * Mark the blind index column as unique.
+     */
+    public function unique(): static
+    {
+        $this->indexColumn->unique();
+        $this->unique = true;
+
+        return $this;
+    }
+
+    /**
+     * Make the columns nullable.
+     */
+    public function nullable(): static
+    {
+        $this->textColumn->nullable()->default(null);
+        $this->indexColumn->nullable()->default(null);
+
+        return $this;
+    }
+
+    public function __destruct()
+    {
+        if (! $this->unique) {
+            $this->indexColumn->index();
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,8 +3,10 @@
 namespace App\Providers;
 
 use App\Auth\BlindIndexUserProvider;
+use App\Database\BlindIndexes\BlindIndexColumn;
 use App\Events\MaterializedViewNeedsRefresh;
 use App\Listeners\RefreshMaterializedView;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
@@ -27,6 +29,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Blueprint::macro('blindIndex', function (string $column) {
+            return new BlindIndexColumn($this, $column);
+        });
+
         /**
          * Register the custom 'blindindex' user provider for encrypted email/blind index authentication.
          * Used for all user lookups in auth (including Filament).

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Database\BlindIndexes\BlindIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,12 +14,10 @@ return new class extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->uuid('id')->primary();
 
-            BlindIndex::table($table)->columns([
-                'email' => ['unique' => true],
-                'first_name' => ['nullable' => true],
-                'last_name' => ['nullable' => true],
-                'pesel' => ['unique' => true, 'nullable' => true],
-            ]);
+            $table->blindIndex('email')->unique();
+            $table->blindIndex('first_name')->nullable();
+            $table->blindIndex('last_name')->nullable();
+            $table->blindIndex('pesel')->unique()->nullable();
 
             $table->enum('language', ['en', 'pl'])->nullable();
 

--- a/tests/Feature/BlindIndexBlueprintMacroTest.php
+++ b/tests/Feature/BlindIndexBlueprintMacroTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class BlindIndexBlueprintMacroTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('macro_records', function (Blueprint $table) {
+            $table->increments('id');
+            $table->blindIndex('secret')->unique();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('macro_records');
+        parent::tearDown();
+    }
+
+    public function test_macro_creates_columns(): void
+    {
+        $this->assertTrue(Schema::hasColumn('macro_records', 'secret'));
+        $this->assertTrue(Schema::hasColumn('macro_records', 'secret_blind_index'));
+    }
+}


### PR DESCRIPTION
## Summary
- add `BlindIndexColumn` for fluent column building
- support `BlindIndex::create()` API
- migrate users table to fluent blind index definitions
- register a Blueprint macro so migrations can call `$table->blindIndex()`
- add a test for the Blueprint macro

## Testing
- `composer --version` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*
- `phpunit` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6839feda83388328949a439b6d02a96a