### PR TITLE
Streamline materialized view builder

### DIFF
--- a/app/Database/Views/MaterializedView.php
+++ b/app/Database/Views/MaterializedView.php
@@ -8,19 +8,15 @@ use Illuminate\Support\Facades\DB;
 
 class MaterializedView
 {
-    protected string $name;
+    protected ?string $rawQuery = null;
 
-    protected string $query;
+    protected ?Builder $builder = null;
 
     /** @var string[] */
     protected array $indexes = [];
 
-    public static function make(string $name): static
+    public function __construct(protected string $name)
     {
-        $instance = new static;
-        $instance->name = $name;
-
-        return $instance;
     }
 
     public function query(Closure|Builder|string $query): static
@@ -30,12 +26,23 @@ class MaterializedView
         }
 
         if ($query instanceof Builder) {
-            $query = $query->toRawSql();
+            $this->builder = $query;
+            $this->rawQuery = null;
+        } else {
+            $this->rawQuery = (string) $query;
+            $this->builder = null;
         }
 
-        $this->query = $query;
-
         return $this;
+    }
+
+    public function __call(string $method, array $parameters)
+    {
+        $this->builder ??= DB::query();
+
+        $result = $this->builder->$method(...$parameters);
+
+        return $result instanceof Builder ? $this : $result;
     }
 
     public function index(string $name, array|string $columns, bool $unique = false): static
@@ -57,14 +64,20 @@ class MaterializedView
 
     public function create(): void
     {
-        DB::statement("CREATE MATERIALIZED VIEW {$this->name} AS {$this->query}");
+        $query = $this->rawQuery;
+
+        if ($this->builder) {
+            $query = $this->builder->toRawSql();
+        }
+
+        DB::statement("CREATE MATERIALIZED VIEW {$this->name} AS {$query}");
 
         foreach ($this->indexes as $sql) {
             DB::statement($sql);
         }
     }
 
-    public function drop(): void
+    public function dropIfExists(): void
     {
         DB::statement("DROP MATERIALIZED VIEW IF EXISTS {$this->name} CASCADE");
     }
@@ -73,5 +86,10 @@ class MaterializedView
     {
         $concurrent = $concurrently ? 'CONCURRENTLY ' : '';
         DB::statement("REFRESH MATERIALIZED VIEW {$concurrent}{$this->name}");
+    }
+
+    public function name(): string
+    {
+        return $this->name;
     }
 }

--- a/app/Listeners/RefreshMaterializedView.php
+++ b/app/Listeners/RefreshMaterializedView.php
@@ -2,13 +2,13 @@
 
 namespace App\Listeners;
 
-use App\Database\Views\MaterializedView;
+use Illuminate\Support\Facades\Schema;
 use App\Events\MaterializedViewNeedsRefresh;
 
 class RefreshMaterializedView
 {
     public function handle(MaterializedViewNeedsRefresh $event): void
     {
-        MaterializedView::make($event->viewName)->refresh($event->concurrently);
+        Schema::refreshMaterializedView($event->viewName, $event->concurrently);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,11 +4,14 @@ namespace App\Providers;
 
 use App\Auth\BlindIndexUserProvider;
 use App\Database\BlindIndexes\BlindIndexColumn;
+use App\Database\Views\MaterializedView;
+use Closure;
 use App\Events\MaterializedViewNeedsRefresh;
 use App\Listeners\RefreshMaterializedView;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -31,6 +34,20 @@ class AppServiceProvider extends ServiceProvider
     {
         Blueprint::macro('blind', function (string $column): BlindIndexColumn {
             return new BlindIndexColumn($this, $column);
+        });
+
+        Schema::macro('createMaterializedView', function (string $name, Closure $callback): void {
+            $view = new MaterializedView($name);
+            $callback($view);
+            $view->create();
+        });
+
+        Schema::macro('dropMaterializedView', function (string $name): void {
+            (new MaterializedView($name))->dropIfExists();
+        });
+
+        Schema::macro('refreshMaterializedView', function (string $name, bool $concurrently = false): void {
+            (new MaterializedView($name))->refresh($concurrently);
         });
 
         /**

--- a/database/migrations/2025_05_29_011217_create_organization_user_features_table.php
+++ b/database/migrations/2025_05_29_011217_create_organization_user_features_table.php
@@ -30,13 +30,13 @@ return new class extends Migration
             $table->foreign('created_by')->references('id')->on('users')->nullOnDelete();
         });
 
-        MaterializedView::make('organization_user')
-            ->query(
-                DB::table('organization_user_features')
-                    ->select('organization_id', 'user_id')->distinct()
-            )
-            ->uniqueIndex('organization_user_pk', ['organization_id', 'user_id'])
-            ->create();
+        Schema::createMaterializedView('organization_user', function (MaterializedView $view) {
+            $view
+                ->select('organization_id', 'user_id')
+                ->distinct()
+                ->from('organization_user_features')
+                ->uniqueIndex('organization_user_pk', ['organization_id', 'user_id']);
+        });
 
     }
 
@@ -46,6 +46,6 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('organization_user_features');
-        MaterializedView::make('organization_user')->drop();
+        Schema::dropMaterializedView('organization_user');
     }
 };


### PR DESCRIPTION
## Summary
- upgrade `MaterializedView` to behave like a query builder so it can be chained with typical builder methods
- create materialized view in migration using the fluent builder syntax

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a09250d0c8328b9875222c708cb8e