### PR TITLE
Improve materialized view index API

### DIFF
--- a/app/Database/Views/MaterializedView.php
+++ b/app/Database/Views/MaterializedView.php
@@ -12,7 +12,11 @@ class MaterializedView
 
     protected ?Builder $builder = null;
 
-    /** @var string[] */
+    /**
+     * SQL statements to create indexes for the view.
+     *
+     * @var string[]
+     */
     protected array $indexes = [];
 
     public function __construct(protected string $name)
@@ -45,21 +49,44 @@ class MaterializedView
         return $result instanceof Builder ? $this : $result;
     }
 
-    public function index(string $name, array|string $columns, bool $unique = false): static
+    protected function addIndex(array|string $columns, ?string $name, bool $unique): static
     {
+        $columnsList = $columns;
+
         if (is_array($columns)) {
-            $columns = implode(', ', $columns);
+            $columnsList = implode(', ', $columns);
+        } else {
+            $columns = [$columns];
         }
 
+        $name ??= $this->generateIndexName($columns, $unique);
+
         $uniqueSql = $unique ? 'UNIQUE ' : '';
-        $this->indexes[] = "CREATE {$uniqueSql}INDEX {$name} ON {$this->name} ({$columns})";
+        $this->indexes[] = "CREATE {$uniqueSql}INDEX {$name} ON {$this->name} ({$columnsList})";
 
         return $this;
     }
 
+    public function index(array|string $columns, ?string $name = null): static
+    {
+        return $this->addIndex($columns, $name, false);
+    }
+
+    public function unique(array|string $columns, ?string $name = null): static
+    {
+        return $this->addIndex($columns, $name, true);
+    }
+
     public function uniqueIndex(string $name, array|string $columns): static
     {
-        return $this->index($name, $columns, true);
+        // Backwards compatibility
+        return $this->addIndex($columns, $name, true);
+    }
+
+    protected function generateIndexName(array $columns, bool $unique): string
+    {
+        $type = $unique ? 'unique' : 'index';
+        return strtolower($this->name.'_'.implode('_', $columns).'_'.$type);
     }
 
     public function create(): void

--- a/database/migrations/2025_05_29_011217_create_organization_user_features_table.php
+++ b/database/migrations/2025_05_29_011217_create_organization_user_features_table.php
@@ -35,7 +35,8 @@ return new class extends Migration
                 ->select('organization_id', 'user_id')
                 ->distinct()
                 ->from('organization_user_features')
-                ->uniqueIndex('organization_user_pk', ['organization_id', 'user_id']);
+                // Unique index on organization and user without custom name
+                ->unique(['organization_id', 'user_id']);
         });
 
     }


### PR DESCRIPTION
## Summary
- add automatic naming for materialized view indexes
- add `unique()` and `index()` helpers
- use the new helper in the organization_user materialized view migration

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683a1530efdc8328bf3a18a3d9adea79