### PR TITLE
Add OrganizationUserEvent materialized views

### DIFF
--- a/app/Database/Views/MaterializedView.php
+++ b/app/Database/Views/MaterializedView.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Database\Views;
+
+use Closure;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+class MaterializedView
+{
+    protected ?string $rawQuery = null;
+
+    protected ?Builder $builder = null;
+
+    /**
+     * SQL statements to create indexes for the view.
+     *
+     * @var string[]
+     */
+    protected array $indexes = [];
+
+    public function __construct(protected string $name)
+    {
+    }
+
+    public function query(Closure|Builder|string $query): static
+    {
+        if ($query instanceof Closure) {
+            $query = $query();
+        }
+
+        if ($query instanceof Builder) {
+            $this->builder = $query;
+            $this->rawQuery = null;
+        } else {
+            $this->rawQuery = (string) $query;
+            $this->builder = null;
+        }
+
+        return $this;
+    }
+
+    public function __call(string $method, array $parameters)
+    {
+        $this->builder ??= DB::query();
+
+        $result = $this->builder->$method(...$parameters);
+
+        return $result instanceof Builder ? $this : $result;
+    }
+
+    protected function addIndex(array|string $columns, ?string $name, bool $unique): static
+    {
+        $columnsList = $columns;
+
+        if (is_array($columns)) {
+            $columnsList = implode(', ', $columns);
+        } else {
+            $columns = [$columns];
+        }
+
+        $name ??= $this->generateIndexName($columns, $unique);
+
+        $uniqueSql = $unique ? 'UNIQUE ' : '';
+        $this->indexes[] = "CREATE {$uniqueSql}INDEX {$name} ON {$this->name} ({$columnsList})";
+
+        return $this;
+    }
+
+    public function index(array|string $columns, ?string $name = null): static
+    {
+        return $this->addIndex($columns, $name, false);
+    }
+
+    public function unique(array|string $columns, ?string $name = null): static
+    {
+        return $this->addIndex($columns, $name, true);
+    }
+
+    public function uniqueIndex(string $name, array|string $columns): static
+    {
+        return $this->addIndex($columns, $name, true);
+    }
+
+    protected function generateIndexName(array $columns, bool $unique): string
+    {
+        $type = $unique ? 'unique' : 'index';
+        return strtolower($this->name.'_'.implode('_', $columns).'_'.$type);
+    }
+
+    public function create(): void
+    {
+        $query = $this->rawQuery;
+
+        if ($this->builder) {
+            $query = $this->builder->toRawSql();
+        }
+
+        DB::statement("CREATE MATERIALIZED VIEW {$this->name} AS {$query}");
+
+        foreach ($this->indexes as $sql) {
+            DB::statement($sql);
+        }
+    }
+
+    public function dropIfExists(): void
+    {
+        DB::statement("DROP MATERIALIZED VIEW IF EXISTS {$this->name} CASCADE");
+    }
+
+    public function refresh(bool $concurrently = false): void
+    {
+        $concurrent = $concurrently ? 'CONCURRENTLY ' : '';
+        DB::statement("REFRESH MATERIALIZED VIEW {$concurrent}{$this->name}");
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/app/Enums/FeatureEvent.php
+++ b/app/Enums/FeatureEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Traits\HasTranslatableLabel;
+
+enum FeatureEvent: string
+{
+    use HasTranslatableLabel;
+
+    case GRANTED = 'granted';
+    case REVOKED = 'revoked';
+
+    protected function translationPrefix(): string
+    {
+        return 'doceus.feature_event';
+    }
+}

--- a/app/Models/OrganizationUserEvent.php
+++ b/app/Models/OrganizationUserEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\FeatureEvent;
+use App\Enums\UserFeature;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class OrganizationUserEvent extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'organization_user_events';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'user_feature' => UserFeature::class,
+        'event' => FeatureEvent::class,
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,10 @@
 namespace App\Providers;
 
 use App\Auth\BlindIndexUserProvider;
+use App\Database\Views\MaterializedView;
+use Closure;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -24,6 +27,20 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Schema::macro('createMaterializedView', function (string $name, Closure $callback): void {
+            $view = new MaterializedView($name);
+            $callback($view);
+            $view->create();
+        });
+
+        Schema::macro('dropMaterializedView', function (string $name): void {
+            (new MaterializedView($name))->dropIfExists();
+        });
+
+        Schema::macro('refreshMaterializedView', function (string $name, bool $concurrently = false): void {
+            (new MaterializedView($name))->refresh($concurrently);
+        });
+
         /**
          * Register the custom 'blindindex' user provider for encrypted email/blind index authentication.
          * Used for all user lookups in auth (including Filament).

--- a/database/migrations/2025_05_30_000000_create_organization_user_events_table.php
+++ b/database/migrations/2025_05_30_000000_create_organization_user_events_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Enums\FeatureEvent;
+use App\Enums\UserFeature;
+use App\Database\Views\MaterializedView;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organization_user_events', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('organization_id');
+            $table->uuid('user_id');
+            $table->enum('user_feature', Arr::pluck(UserFeature::cases(), 'value'));
+            $table->enum('event', Arr::pluck(FeatureEvent::cases(), 'value'));
+            $table->timestamps();
+
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+
+        Schema::createMaterializedView('organization_user_feature', function (MaterializedView $view) {
+            $view->query(<<<SQL
+SELECT organization_id, user_id, user_feature
+FROM (
+    SELECT organization_id,
+           user_id,
+           user_feature,
+           event,
+           created_at,
+           ROW_NUMBER() OVER (PARTITION BY organization_id, user_id, user_feature ORDER BY created_at DESC) AS rn
+    FROM organization_user_events
+) t
+WHERE rn = 1 AND event = 'granted'
+SQL);
+
+            $view->unique(['organization_id', 'user_id', 'user_feature']);
+        });
+
+        Schema::createMaterializedView('organization_user', function (MaterializedView $view) {
+            $view
+                ->select('organization_id', 'user_id')
+                ->distinct()
+                ->from('organization_user_events')
+                ->unique(['organization_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropMaterializedView('organization_user');
+        Schema::dropMaterializedView('organization_user_feature');
+        Schema::dropIfExists('organization_user_events');
+    }
+};

--- a/lang/en/doceus.php
+++ b/lang/en/doceus.php
@@ -37,6 +37,10 @@ return [
         'is_owner' => 'Owner',
         'is_user' => 'User',
     ],
+    'feature_event' => [
+        'granted' => 'Granted',
+        'revoked' => 'Revoked',
+    ],
     'language' => [
         'en' => 'English',
         'pl' => 'Polish',

--- a/lang/pl/doceus.php
+++ b/lang/pl/doceus.php
@@ -37,6 +37,10 @@ return [
         'is_owner' => 'Właściciel',
         'is_user' => 'Użytkownik',
     ],
+    'feature_event' => [
+        'granted' => 'Przyznano',
+        'revoked' => 'Cofnięto',
+    ],
     'language' => [
         'en' => 'Angielski',
         'pl' => 'Polski',


### PR DESCRIPTION
## Summary
- add `FeatureEvent` enum with translatable labels
- support materialized views via `MaterializedView` helper and Schema macros
- change `OrganizationUserEvent` model to use enum casts
- update event migration to build `organization_user_feature` and `organization_user` materialized views
- extend translations with feature event labels

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a1e45cd4883288cfa17445f3a0e2c