### PR TITLE
Add Sqid feature tests

### DIFF
--- a/tests/Feature/SqidTest.php
+++ b/tests/Feature/SqidTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Feature\Sqid\Sqid;
+use App\Models\Organization;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SqidTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_encode_and_decode(): void
+    {
+        config()->set('sqid.alphabet', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+        config()->set('sqid.length', 5);
+
+        $encoded = Sqid::encode(42);
+        $this->assertIsString($encoded);
+        $this->assertSame(42, Sqid::decode($encoded));
+    }
+
+    public function test_trait_generates_sqid_and_route_binding(): void
+    {
+        config()->set('sqid.alphabets.organization', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+        config()->set('sqid.length', 5);
+
+        $organization = Organization::factory()->create();
+
+        $this->assertIsString($organization->sqid);
+        $this->assertSame($organization->id, Sqid::decode($organization->sqid));
+        $this->assertSame($organization->sqid, $organization->getRouteKey());
+
+        $resolved = $organization->resolveRouteBinding($organization->sqid);
+        $this->assertTrue($organization->is($resolved));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering encode/decode logic for Sqid
- ensure models using HasSqids properly encode ids and resolve route bindings

## Testing
- `php artisan test --testsuite Feature --filter SqidTest` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845d38cfc3c8328b2a757b4671a4dc4