### PR TITLE
Fix force delete revision issue

### DIFF
--- a/app/Feature/Revision/Observers/RevisionableObserver.php
+++ b/app/Feature/Revision/Observers/RevisionableObserver.php
@@ -50,6 +50,11 @@ class RevisionableObserver
 
     public function deleted(Model $model): void
     {
+        if ((method_exists($model, 'isForceDeleting') && $model->isForceDeleting()) ||
+            (property_exists($model, 'forceDeleting') && $model->forceDeleting)) {
+            return;
+        }
+
         $this->dispatchRevisionJob($model, RevisionType::Deleted);
     }
 


### PR DESCRIPTION
## Summary
- skip creating a Deleted revision when model is being force deleted

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: composer not found)*
- `./vendor/bin/phpunit --filter Revision` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845da1d9d6483288f0ad8d5bd2e1b2f