### PR TITLE
Fix revision test setup

### DIFF
--- a/tests/Feature/RevisionTest.php
+++ b/tests/Feature/RevisionTest.php
@@ -106,8 +106,8 @@ class RevisionTest extends TestCase
 
     public function test_person_revisions_for_crud(): void
     {
-        $initial = Revision::count();
         $org = Organization::factory()->create();
+        $initial = Revision::count();
         $person = Person::factory()->for($org)->create();
         $this->assertSame($initial + 1, Revision::count());
         $this->assertDatabaseHas('revisions', [


### PR DESCRIPTION
## Summary
- adjust `test_person_revisions_for_crud` so the initial revision count is set after creating the organization

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845df6582348328a1c46ef1f4720ca8