### PR TITLE
Add comprehensive seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,11 @@
 
 namespace Database\Seeders;
 
+use App\Models\Organization;
+use App\Models\Person;
 use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -13,10 +17,46 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        // Create some users
+        $users = User::factory(5)->create();
 
-        User::factory()->create([
-            'email' => fake()->unique()->safeEmail(),
-        ]);
+        $organizations = collect();
+
+        // Each user creates some organizations outside of tenancy
+        $users->each(function (User $user) use (&$organizations) {
+            Auth::login($user);
+            Filament::setTenant(null);
+
+            $created = Organization::factory(random_int(1, 3))->create();
+            $organizations->push(...$created);
+
+            $user->organizations()->attach($created->pluck('id'));
+
+            Auth::logout();
+        });
+
+        // Attach additional users to random organizations
+        $organizations->each(function (Organization $organization) use ($users) {
+            $otherUsers = $users->random(random_int(0, $users->count() - 1));
+            $organization->users()->syncWithoutDetaching($otherUsers->pluck('id'));
+        });
+
+        // Seed persons for each organization acting as a user within tenancy
+        $organizations->each(function (Organization $organization) {
+            $actingUser = $organization->users()->inRandomOrder()->first();
+
+            if ($actingUser) {
+                Auth::login($actingUser);
+            }
+
+            Filament::setTenant($organization);
+
+            Person::factory(random_int(5, 15))
+                ->for($organization)
+                ->create();
+
+            Auth::logout();
+            Filament::setTenant(null);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- populate users, organizations and persons for dev/testing

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e191561083289f20ba3d0a54fb5a