### PR TITLE
Fix revision test setup

### DIFF
--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class OrganizationFactory extends Factory
 {
     protected $model = Organization::class;
+    protected static ?string $fakerLocale = 'pl_PL';
 
     public function definition(): array
     {

--- a/database/factories/PersonFactory.php
+++ b/database/factories/PersonFactory.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class PersonFactory extends Factory
 {
     protected $model = Person::class;
+    protected static ?string $fakerLocale = 'pl_PL';
 
     public function definition(): array
     {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     protected $model = User::class;
+    protected static ?string $fakerLocale = 'pl_PL';
 
     public function definition(): array
     {

--- a/tests/Feature/RevisionTest.php
+++ b/tests/Feature/RevisionTest.php
@@ -106,8 +106,8 @@ class RevisionTest extends TestCase
 
     public function test_person_revisions_for_crud(): void
     {
-        $initial = Revision::count();
         $org = Organization::factory()->create();
+        $initial = Revision::count();
         $person = Person::factory()->for($org)->create();
         $this->assertSame($initial + 1, Revision::count());
         $this->assertDatabaseHas('revisions', [


### PR DESCRIPTION
## Summary
- adjust `test_person_revisions_for_crud` so the initial revision count is set after creating the organization
- use Polish faker locale in factories

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845df6582348328a1c46ef1f4720ca8