### PR TITLE
Fix patient edit not loading data

### DIFF
--- a/app/Filament/Clusters/Managment/Resources/PatientResource.php
+++ b/app/Filament/Clusters/Managment/Resources/PatientResource.php
@@ -8,8 +8,12 @@ use App\Filament\Clusters\Managment\Resources\PatientResource\Pages;
 use App\Models\Patient;
 use Eloquent;
 use Filament\Forms;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use App\Feature\Identity\Enums\ContactableType;
+use App\Feature\Identity\Enums\ContactPointSystem;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
@@ -55,31 +59,33 @@ class PatientResource extends Resource
             Forms\Components\DatePicker::make('person.birth_date')
                 ->label(__('Birth Date')),
 
-            Select::make('person.emails')
+            Repeater::make('person.emails')
                 ->label(__('Emails'))
-                ->relationship('person.emails', 'value')
-                ->multiple()
-                ->preload()
-                ->searchable()
-                ->createOptionForm([
+                ->schema([
+                    Hidden::make('contactable_type')
+                        ->default(ContactableType::Person),
+                    Hidden::make('system')
+                        ->default(ContactPointSystem::Email),
                     TextInput::make('value')
                         ->label(__('Email'))
                         ->email()
                         ->required(),
-                ]),
+                ])
+                ->defaultItems(0),
 
-            Select::make('person.phones')
+            Repeater::make('person.phones')
                 ->label(__('Phones'))
-                ->relationship('person.phones', 'value')
-                ->multiple()
-                ->preload()
-                ->searchable()
-                ->createOptionForm([
+                ->schema([
+                    Hidden::make('contactable_type')
+                        ->default(ContactableType::Person),
+                    Hidden::make('system')
+                        ->default(ContactPointSystem::Phone),
                     TextInput::make('value')
                         ->label(__('Phone'))
                         ->tel()
                         ->required(),
-                ]),
+                ])
+                ->defaultItems(0),
         ]);
     }
 

--- a/app/Filament/Clusters/Managment/Resources/PatientResource.php
+++ b/app/Filament/Clusters/Managment/Resources/PatientResource.php
@@ -2,9 +2,9 @@
 
 namespace App\Filament\Clusters\Managment\Resources;
 
+use App\Feature\Identity\Enums\Gender;
 use App\Filament\Clusters\Managment;
 use App\Filament\Clusters\Managment\Resources\PatientResource\Pages;
-use App\Feature\Identity\Enums\Gender;
 use App\Models\Patient;
 use Eloquent;
 use Filament\Forms;
@@ -62,7 +62,7 @@ class PatientResource extends Resource
                 ->preload()
                 ->searchable()
                 ->createOptionForm([
-                    TextInput::make('email')
+                    TextInput::make('value')
                         ->label(__('Email'))
                         ->email()
                         ->required(),
@@ -75,7 +75,7 @@ class PatientResource extends Resource
                 ->preload()
                 ->searchable()
                 ->createOptionForm([
-                    TextInput::make('phone')
+                    TextInput::make('value')
                         ->label(__('Phone'))
                         ->tel()
                         ->required(),
@@ -157,7 +157,6 @@ class PatientResource extends Resource
 
     public static function resolveRecordRouteBinding($key): Eloquent
     {
-        return (new Patient())->resolveRouteBinding($key);
+        return (new Patient)->resolveRouteBinding($key);
     }
 }
-

--- a/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/CreatePatient.php
+++ b/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/CreatePatient.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Clusters\Managment\Resources\PatientResource\Pages;
 
 use App\Filament\Clusters\Managment\Resources\PatientResource;
+use App\Feature\Identity\Enums\ContactPointSystem;
+use App\Feature\Identity\Enums\ContactableType;
 use App\Models\Person;
 use Filament\Resources\Pages\CreateRecord;
 
@@ -14,7 +16,34 @@ class CreatePatient extends CreateRecord
     {
         $personData = $data['person'] ?? [];
 
+        $emails = collect($personData['emails'] ?? [])
+            ->pluck('value')
+            ->filter()
+            ->toArray();
+        $phones = collect($personData['phones'] ?? [])
+            ->pluck('value')
+            ->filter()
+            ->toArray();
+
+        unset($personData['emails'], $personData['phones']);
+
         $person = Person::create($personData);
+
+        foreach ($emails as $email) {
+            $person->contactPoints()->create([
+                'contactable_type' => ContactableType::Person,
+                'system' => ContactPointSystem::Email,
+                'value' => $email,
+            ]);
+        }
+
+        foreach ($phones as $phone) {
+            $person->contactPoints()->create([
+                'contactable_type' => ContactableType::Person,
+                'system' => ContactPointSystem::Phone,
+                'value' => $phone,
+            ]);
+        }
 
         $data['person_id'] = $person->id;
 

--- a/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/CreatePatient.php
+++ b/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/CreatePatient.php
@@ -3,10 +3,23 @@
 namespace App\Filament\Clusters\Managment\Resources\PatientResource\Pages;
 
 use App\Filament\Clusters\Managment\Resources\PatientResource;
+use App\Models\Person;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreatePatient extends CreateRecord
 {
     protected static string $resource = PatientResource::class;
-}
 
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $personData = $data['person'] ?? [];
+
+        $person = Person::create($personData);
+
+        $data['person_id'] = $person->id;
+
+        unset($data['person']);
+
+        return $data;
+    }
+}

--- a/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/EditPatient.php
+++ b/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/EditPatient.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Clusters\Managment\Resources\PatientResource\Pages;
 
 use App\Filament\Clusters\Managment\Resources\PatientResource;
+use App\Feature\Identity\Enums\ContactableType;
+use App\Feature\Identity\Enums\ContactPointSystem;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -21,12 +23,53 @@ class EditPatient extends EditRecord
             'birth_date',
         ]);
 
+        $data['person']['emails'] = $this->record->person->emails
+            ->pluck('value')
+            ->map(fn ($value) => ['value' => $value])
+            ->toArray();
+
+        $data['person']['phones'] = $this->record->person->phones
+            ->pluck('value')
+            ->map(fn ($value) => ['value' => $value])
+            ->toArray();
+
         return $data;
     }
 
     protected function mutateFormDataBeforeSave(array $data): array
     {
-        $this->record->person->update($data['person'] ?? []);
+        $personData = $data['person'] ?? [];
+
+        $emails = collect($personData['emails'] ?? [])
+            ->pluck('value')
+            ->filter()
+            ->toArray();
+        $phones = collect($personData['phones'] ?? [])
+            ->pluck('value')
+            ->filter()
+            ->toArray();
+
+        unset($personData['emails'], $personData['phones']);
+
+        $this->record->person->update($personData);
+
+        $this->record->person->emails()->delete();
+        foreach ($emails as $email) {
+            $this->record->person->contactPoints()->create([
+                'contactable_type' => ContactableType::Person,
+                'system' => ContactPointSystem::Email,
+                'value' => $email,
+            ]);
+        }
+
+        $this->record->person->phones()->delete();
+        foreach ($phones as $phone) {
+            $this->record->person->contactPoints()->create([
+                'contactable_type' => ContactableType::Person,
+                'system' => ContactPointSystem::Phone,
+                'value' => $phone,
+            ]);
+        }
 
         unset($data['person']);
 

--- a/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/EditPatient.php
+++ b/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/EditPatient.php
@@ -24,13 +24,23 @@ class EditPatient extends EditRecord
         ]);
 
         $data['person']['emails'] = $this->record->person->emails
-            ->pluck('value')
-            ->map(fn ($value) => ['value' => $value])
+            ->map(
+                fn ($point) => [
+                    'value' => $point->value,
+                    'contactable_type' => ContactableType::Person,
+                    'system' => ContactPointSystem::Email,
+                ],
+            )
             ->toArray();
 
         $data['person']['phones'] = $this->record->person->phones
-            ->pluck('value')
-            ->map(fn ($value) => ['value' => $value])
+            ->map(
+                fn ($point) => [
+                    'value' => $point->value,
+                    'contactable_type' => ContactableType::Person,
+                    'system' => ContactPointSystem::Phone,
+                ],
+            )
             ->toArray();
 
         return $data;

--- a/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/EditPatient.php
+++ b/app/Filament/Clusters/Managment/Resources/PatientResource/Pages/EditPatient.php
@@ -10,6 +10,29 @@ class EditPatient extends EditRecord
 {
     protected static string $resource = PatientResource::class;
 
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        $data['person'] = $this->record->person->only([
+            'first_name',
+            'last_name',
+            'pesel',
+            'id_number',
+            'gender',
+            'birth_date',
+        ]);
+
+        return $data;
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->record->person->update($data['person'] ?? []);
+
+        unset($data['person']);
+
+        return $data;
+    }
+
     protected function getHeaderActions(): array
     {
         return [
@@ -17,4 +40,3 @@ class EditPatient extends EditRecord
         ];
     }
 }
-

--- a/app/Filament/Clusters/Managment/Resources/PersonResource.php
+++ b/app/Filament/Clusters/Managment/Resources/PersonResource.php
@@ -9,7 +9,10 @@ use App\Models\Person;
 use Eloquent;
 use Filament\Facades\Filament;
 use Filament\Forms;
+use App\Feature\Identity\Enums\ContactableType;
+use App\Feature\Identity\Enums\ContactPointSystem;
 use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
@@ -59,30 +62,34 @@ class PersonResource extends Resource
             Hidden::make('organization_id')
                 ->default(fn () => Filament::getTenant()?->getKey())
                 ->required(),
-            Select::make('emails')
+            Repeater::make('emails')
                 ->label(__('Emails'))
-                ->relationship('emails', 'value')
-                ->multiple()
-                ->preload()
-                ->searchable()
-                ->createOptionForm([
+                ->relationship()
+                ->schema([
+                    Hidden::make('contactable_type')
+                        ->default(ContactableType::Person),
+                    Hidden::make('system')
+                        ->default(ContactPointSystem::Email),
                     TextInput::make('value')
                         ->label(__('Email'))
                         ->email()
                         ->required(),
-                ]),
-            Select::make('phones')
+                ])
+                ->defaultItems(0),
+            Repeater::make('phones')
                 ->label(__('Phones'))
-                ->relationship('phones', 'value')
-                ->multiple()
-                ->preload()
-                ->searchable()
-                ->createOptionForm([
+                ->relationship()
+                ->schema([
+                    Hidden::make('contactable_type')
+                        ->default(ContactableType::Person),
+                    Hidden::make('system')
+                        ->default(ContactPointSystem::Phone),
                     TextInput::make('value')
                         ->label(__('Phone'))
                         ->tel()
                         ->required(),
-                ]),
+                ])
+                ->defaultItems(0),
         ]);
     }
 

--- a/app/Filament/Clusters/Managment/Resources/PersonResource.php
+++ b/app/Filament/Clusters/Managment/Resources/PersonResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Filament\Clusters\Managment\Resources;
 
-use Filament\Forms\Components\Select;
 use App\Feature\Identity\Enums\Gender;
 use App\Filament\Clusters\Managment;
 use App\Filament\Clusters\Managment\Resources\PersonResource\Pages;
@@ -11,6 +10,7 @@ use Eloquent;
 use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Tables;
@@ -57,28 +57,28 @@ class PersonResource extends Resource
             Forms\Components\DatePicker::make('birth_date')
                 ->label(__('Birth Date')),
             Hidden::make('organization_id')
-                ->default(fn () => Filament::getTenant()?->getKey())    
+                ->default(fn () => Filament::getTenant()?->getKey())
                 ->required(),
             Select::make('emails')
                 ->label(__('Emails'))
-                ->relationship('emails', 'email')
+                ->relationship('emails', 'value')
                 ->multiple()
                 ->preload()
                 ->searchable()
                 ->createOptionForm([
-                    TextInput::make('email')
+                    TextInput::make('value')
                         ->label(__('Email'))
                         ->email()
                         ->required(),
                 ]),
             Select::make('phones')
                 ->label(__('Phones'))
-                ->relationship('phones', 'phone')
+                ->relationship('phones', 'value')
                 ->multiple()
                 ->preload()
                 ->searchable()
                 ->createOptionForm([
-                    TextInput::make('phone')
+                    TextInput::make('value')
                         ->label(__('Phone'))
                         ->tel()
                         ->required(),

--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -37,7 +37,7 @@ class EditProfile extends BasePage
 
     protected function getFirstNameFormComponent(): TextInput
     {
-        return TextInput::make('first_name')
+        return TextInput::make('person.first_name')
             ->label(__('doceus.auth.first_name'))
             ->required()
             ->maxLength(255)
@@ -46,7 +46,7 @@ class EditProfile extends BasePage
 
     protected function getLastNameFormComponent(): TextInput
     {
-        return TextInput::make('last_name')
+        return TextInput::make('person.last_name')
             ->label(__('doceus.auth.last_name'))
             ->required()
             ->maxLength(255);
@@ -54,7 +54,7 @@ class EditProfile extends BasePage
 
     protected function getPeselFormComponent(): TextInput
     {
-        return TextInput::make('pesel')
+        return TextInput::make('person.pesel')
             ->label(__('PESEL'))
             ->required()
             ->mask('99999999999');
@@ -62,14 +62,11 @@ class EditProfile extends BasePage
 
     /**
      * Load data from the authenticated user's related Person record.
+     * @throws \Exception
      */
     protected function mutateFormDataBeforeFill(array $data): array
     {
-        return $this->getUser()->person->only([
-            'first_name',
-            'last_name',
-            'pesel',
-        ]);
+        return $this->getUser()->with('person')->first()->toArray();
     }
 
     /**

--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -59,4 +59,26 @@ class EditProfile extends BasePage
             ->required()
             ->mask('99999999999');
     }
+
+    /**
+     * Load data from the authenticated user's related Person record.
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return $this->getUser()->person->only([
+            'first_name',
+            'last_name',
+            'pesel',
+        ]);
+    }
+
+    /**
+     * Persist profile updates to the Person model instead of the User.
+     */
+    protected function handleRecordUpdate(\Illuminate\Database\Eloquent\Model $record, array $data): \Illuminate\Database\Eloquent\Model
+    {
+        $record->person->update($data);
+
+        return $record;
+    }
 }


### PR DESCRIPTION
## Summary
- fix contact point relationship fields to use `value`
- load and save `Person` details when creating or editing patients

## Testing
- `composer test` *(fails: Test directory "/workspace/doceus/tests/Unit" not found)*

------
https://chatgpt.com/codex/tasks/task_e_684774f0230883289ecf96349b8d7156