### PR TITLE
Add tests and translation updates

### DIFF
--- a/lang/en/doceus.php
+++ b/lang/en/doceus.php
@@ -51,6 +51,13 @@ return [
         'granted' => 'Granted',
         'revoked' => 'Revoked',
     ],
+    'revision_type' => [
+        'created' => 'Created',
+        'updated' => 'Updated',
+        'deleted' => 'Deleted',
+        'restored' => 'Restored',
+        'force_deleted' => 'Force Deleted',
+    ],
     'language' => [
         'en' => 'English',
         'pl' => 'Polish',
@@ -64,6 +71,7 @@ return [
         'male' => 'Male',
         'female' => 'Female',
         'other' => 'Other',
+        'unknown' => 'Unknown',
     ],
     'birth_date' => 'Birth Date',
     'id_number' => 'ID Number',

--- a/lang/pl/doceus.php
+++ b/lang/pl/doceus.php
@@ -51,6 +51,13 @@ return [
         'granted' => 'Przyznano',
         'revoked' => 'Cofnięto',
     ],
+    'revision_type' => [
+        'created' => 'Utworzono',
+        'updated' => 'Zaktualizowano',
+        'deleted' => 'Usunięto',
+        'restored' => 'Przywrócono',
+        'force_deleted' => 'Usunięto trwale',
+    ],
     'language' => [
         'en' => 'Angielski',
         'pl' => 'Polski',
@@ -64,6 +71,7 @@ return [
         'male' => 'Mężczyzna',
         'female' => 'Kobieta',
         'other' => 'Inna',
+        'unknown' => 'Nieznana',
     ],
     'birth_date' => 'Data urodzenia',
     'id_number' => 'Numer dokumentu',

--- a/tests/Feature/EnumLabelTest.php
+++ b/tests/Feature/EnumLabelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Feature\Identity\Enums\Gender;
+use App\Feature\Identity\Enums\OrganizationType;
+use App\Feature\Revision\Enums\RevisionType;
+use App\Enums\Language;
+use Tests\TestCase;
+
+class EnumLabelTest extends TestCase
+{
+    public function test_gender_labels_are_translated(): void
+    {
+        app()->setLocale('en');
+        foreach (Gender::cases() as $gender) {
+            $this->assertNotSame('doceus.gender.' . $gender->value, $gender->label());
+        }
+    }
+
+    public function test_organization_type_labels_are_translated(): void
+    {
+        app()->setLocale('en');
+        foreach (OrganizationType::cases() as $type) {
+            $this->assertNotSame('doceus.organization_type.' . $type->value, $type->label());
+        }
+    }
+
+    public function test_revision_type_labels_are_translated(): void
+    {
+        app()->setLocale('en');
+        foreach (RevisionType::cases() as $type) {
+            $this->assertNotSame('doceus.revision_type.' . $type->value, $type->label());
+        }
+    }
+
+    public function test_language_labels_are_translated(): void
+    {
+        app()->setLocale('en');
+        foreach (Language::cases() as $lang) {
+            $this->assertNotSame('doceus.language.' . $lang->value, $lang->label());
+        }
+    }
+}

--- a/tests/Feature/PeselServiceTest.php
+++ b/tests/Feature/PeselServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Feature\Identity\Services\Pesel;
+use App\Feature\Identity\Enums\Gender;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class PeselServiceTest extends TestCase
+{
+    public function test_extract_birth_date_from_valid_pesel(): void
+    {
+        $birthDate = Pesel::extractBirthDate('44051401359');
+        $this->assertInstanceOf(Carbon::class, $birthDate);
+        $this->assertSame('1944-05-14', $birthDate->format('Y-m-d'));
+    }
+
+    public function test_extract_birth_date_returns_null_for_invalid_pesel(): void
+    {
+        $this->assertNull(Pesel::extractBirthDate('1234567890'));
+    }
+
+    public function test_extract_gender_from_valid_pesel(): void
+    {
+        $gender = Pesel::extractGender('44051401359');
+        $this->assertSame(Gender::Male, $gender);
+    }
+
+    public function test_extract_gender_returns_null_for_invalid_pesel(): void
+    {
+        $this->assertNull(Pesel::extractGender('invalid'));
+    }
+}

--- a/tests/Unit/.gitkeep
+++ b/tests/Unit/.gitkeep
@@ -1,0 +1,1 @@
+# Keep for PHPUnit


### PR DESCRIPTION
## Summary
- test that enum labels are translated
- add missing gender/unknown translation
- add revision type translations
- test Pesel service birth date and gender extraction

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68478091d1b88328a492953135f9f16d