### PR TITLE
Fix PractitionerQualification enum typo

### DIFF
--- a/app/Feature/Identity/Enums/PractitionerQualification.php
+++ b/app/Feature/Identity/Enums/PractitionerQualification.php
@@ -2,7 +2,7 @@
 
 namespace App\Feature\Identity\Enums;
 
-enum PrectitionerQualification: string
+enum PractitionerQualification: string
 {
     case MedicalStudent = 'medical_student';
     case MedicalIntern = 'medical_intern';

--- a/app/Models/PractitionerQualification.php
+++ b/app/Models/PractitionerQualification.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Feature\Identity\Enums\PrectitionerQualification;
+use App\Feature\Identity\Enums\PractitionerQualification as PractitionerQualificationEnum;
 use App\Feature\Revision\Interfaces\Revisionable;
 use App\Feature\Revision\Observers\RevisionableObserver;
 use App\Feature\Revision\Traits\LogsRevisions;
@@ -28,7 +28,7 @@ class PractitionerQualification extends BaseModel
     ];
 
     protected $casts = [
-        'qualification' => PrectitionerQualification::class,
+        'qualification' => PractitionerQualificationEnum::class,
         'valid_from' => 'datetime',
         'valid_to' => 'datetime',
     ];

--- a/database/factories/PractitionerQualificationFactory.php
+++ b/database/factories/PractitionerQualificationFactory.php
@@ -2,7 +2,7 @@
 
 namespace Database\Factories;
 
-use App\Feature\Identity\Enums\PrectitionerQualification;
+use App\Feature\Identity\Enums\PractitionerQualification;
 use App\Models\Practitioner;
 use App\Models\PractitionerQualification;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -15,7 +15,7 @@ class PractitionerQualificationFactory extends Factory
     {
         return [
             'practitioner_id' => Practitioner::factory(),
-            'qualification' => $this->faker->randomElement(array_map(fn ($q) => $q->value, PrectitionerQualification::cases())),
+            'qualification' => $this->faker->randomElement(array_map(fn ($q) => $q->value, PractitionerQualification::cases())),
             'valid_from' => $this->faker->dateTimeBetween('-10 years', '-5 years'),
             'valid_to' => $this->faker->dateTimeBetween('-4 years', 'now'),
         ];

--- a/database/migrations/2025_06_09_181102_create_practitioner_qualifications_table.php
+++ b/database/migrations/2025_06_09_181102_create_practitioner_qualifications_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Feature\Identity\Enums\PrectitionerQualification;
+use App\Feature\Identity\Enums\PractitionerQualification;
 use App\Models\Practitioner;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('practitioner_qualifications', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Practitioner::class);
-            $table->enum('qualification', Arr::pluck(PrectitionerQualification::cases(), 'value'));
+            $table->enum('qualification', Arr::pluck(PractitionerQualification::cases(), 'value'));
             $table->timestamp('valid_from')->nullable();
             $table->timestamp('valid_to')->nullable();
             $table->timestamps();


### PR DESCRIPTION
## Summary
- rename `PrectitionerQualification` enum to `PractitionerQualification`
- update model, factory and migration references

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6849782f5d048328958ecbb8b5d04cd7