### PR TITLE
Fix PractitionerQualificationFactory alias conflict

### DIFF
--- a/database/factories/PractitionerQualificationFactory.php
+++ b/database/factories/PractitionerQualificationFactory.php
@@ -2,8 +2,9 @@
 
 namespace Database\Factories;
 
-use App\Feature\Identity\Enums\PractitionerQualification;
+use App\Feature\Identity\Enums\PractitionerQualification as PractitionerQualificationEnum;
 use App\Models\Practitioner;
+use App\Models\PractitionerQualification;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class PractitionerQualificationFactory extends Factory
@@ -14,7 +15,7 @@ class PractitionerQualificationFactory extends Factory
     {
         return [
             'practitioner_id' => Practitioner::factory(),
-            'qualification' => $this->faker->randomElement(array_map(fn ($q) => $q->value, PractitionerQualification::cases())),
+            'qualification' => $this->faker->randomElement(array_map(fn ($q) => $q->value, PractitionerQualificationEnum::cases())),
             'valid_from' => $this->faker->dateTimeBetween('-10 years', '-5 years'),
             'valid_to' => $this->faker->dateTimeBetween('-4 years', 'now'),
         ];


### PR DESCRIPTION
## Summary
- fix enumeration/model name conflict in PractitionerQualificationFactory

## Testing
- `composer install --no-interaction --no-progress`
- `npm install --no-audit --progress=false`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6849af98239483288465a709abf0daec