### PR TITLE
Add tagging resource and patient toggle integration

### DIFF
--- a/app/Filament/Resources/PatientResource.php
+++ b/app/Filament/Resources/PatientResource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PatientResource\Pages;
+use App\Models\Patient;
+use App\Models\Tag;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PatientResource extends Resource
+{
+    protected static ?string $model = Patient::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-user';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Split::make([
+                    Forms\Components\Section::make([
+                        Forms\Components\Select::make('person_id')
+                            ->relationship('person', 'first_name')
+                            ->searchable()
+                            ->required(),
+                    ])->grow(),
+                    Forms\Components\Section::make([
+                        Forms\Components\ToggleButtons::make('tags')
+                            ->relationship('tags', 'name')
+                            ->options(fn () => Tag::pluck('name', 'id')->toArray())
+                            ->columns(1)
+                            ->multiple(),
+                    ])->grow(false),
+                ])->from('md'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id'),
+                Tables\Columns\TextColumn::make('person.first_name')->label('First name'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ManagePatients::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PatientResource/Pages/ManagePatients.php
+++ b/app/Filament/Resources/PatientResource/Pages/ManagePatients.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PatientResource\Pages;
+
+use App\Filament\Resources\PatientResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManagePatients extends ManageRecords
+{
+    protected static string $resource = PatientResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/TagResource.php
+++ b/app/Filament/Resources/TagResource.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\TagResource\Pages;
+use App\Models\Tag;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class TagResource extends Resource
+{
+    protected static ?string $model = Tag::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-tag';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\ColorPicker::make('color')
+                    ->nullable(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\ColorColumn::make('color'),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ManageTags::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TagResource/Pages/ManageTags.php
+++ b/app/Filament/Resources/TagResource/Pages/ManageTags.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\TagResource\Pages;
+
+use App\Filament\Resources\TagResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageTags extends ManageRecords
+{
+    protected static string $resource = TagResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use App\Models\Organization;
 use App\Models\OrganizationPatient;
+use App\Models\PatientTag;
+use App\Models\Tag;
 
 class Patient extends BaseModel
 {
@@ -22,6 +24,11 @@ class Patient extends BaseModel
     protected array $revisionable = [
         'person_id',
     ];
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class)->using(PatientTag::class);
+    }
 
     public function person(): BelongsTo
     {

--- a/app/Models/PatientTag.php
+++ b/app/Models/PatientTag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+/**
+ * @property int $patient_id
+ * @property int $tag_id
+ */
+class PatientTag extends BasePivot
+{
+    protected array $revisionable = [
+        'patient_id',
+        'tag_id',
+    ];
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string|null $color
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Patient> $patients
+ * @property-read int|null $patients_count
+ */
+class Tag extends BaseModel
+{
+    protected $fillable = [
+        'name',
+        'color',
+    ];
+
+    protected array $revisionable = [
+        'name',
+        'color',
+    ];
+
+    public function patients(): BelongsToMany
+    {
+        return $this->belongsToMany(Patient::class)->using(PatientTag::class);
+    }
+}

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TagFactory extends Factory
+{
+    protected $model = Tag::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'color' => $this->faker->safeHexColor(),
+        ];
+    }
+}

--- a/database/migrations/2025_06_09_191000_create_tags_table.php
+++ b/database/migrations/2025_06_09_191000_create_tags_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\Tag;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('color')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2025_06_09_191100_create_patient_tag_table.php
+++ b/database/migrations/2025_06_09_191100_create_patient_tag_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Patient;
+use App\Models\Tag;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('patient_tag', function (Blueprint $table) {
+            $table->foreignIdFor(Patient::class)
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->foreignIdFor(Tag::class)
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['patient_id', 'tag_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('patient_tag');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -7,6 +7,7 @@ use App\Models\Person;
 use App\Models\ContactPoint;
 use App\Models\Patient;
 use App\Models\PractitionerQualification;
+use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 
@@ -18,6 +19,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $organizations = Organization::factory(5)->create();
+
+        Tag::factory(5)->create();
 
         $users = User::factory(5)->create();
 
@@ -54,6 +57,9 @@ class DatabaseSeeder extends Seeder
                 ->create()
                 ->each(function (Patient $patient) use ($organization) {
                     $patient->organizations()->attach($organization);
+                    $patient->tags()->attach(
+                        Tag::inRandomOrder()->take(random_int(0, 3))->pluck('id')
+                    );
                     ContactPoint::factory(random_int(1, 2))
                         ->for($patient->person, 'person')
                         ->email()


### PR DESCRIPTION
## Summary
- introduce `Tag` model, pivot, and factories
- migrate `tags` and `patient_tag` tables
- seed sample tags and assign them to patients
- create `TagResource` for managing tags
- create `PatientResource` with sidebar tag toggles

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684a0b9b701083289dc8b1df68b245dc