### PR TITLE
Add tag management and patient tagging

### DIFF
--- a/app/Filament/Resources/Patients/Pages/CreatePatient.php
+++ b/app/Filament/Resources/Patients/Pages/CreatePatient.php
@@ -8,4 +8,19 @@ use Filament\Resources\Pages\CreateRecord;
 class CreatePatient extends CreateRecord
 {
     protected static string $resource = PatientResource::class;
+
+    protected array $tagIds = [];
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->tagIds = $data['tag_ids'] ?? [];
+        unset($data['tag_ids']);
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        $this->record->tags()->sync($this->tagIds);
+    }
 }

--- a/app/Filament/Resources/Patients/Pages/EditPatient.php
+++ b/app/Filament/Resources/Patients/Pages/EditPatient.php
@@ -12,6 +12,21 @@ class EditPatient extends EditRecord
 {
     protected static string $resource = PatientResource::class;
 
+    protected array $tagIds = [];
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->tagIds = $data['tag_ids'] ?? [];
+        unset($data['tag_ids']);
+
+        return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        $this->record->tags()->sync($this->tagIds);
+    }
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Filament/Resources/Patients/Schemas/PatientForm.php
+++ b/app/Filament/Resources/Patients/Schemas/PatientForm.php
@@ -58,6 +58,14 @@ class PatientForm
                     ]),
                     Group::make()
                     ->grow(false)
+                    ->schema([
+                        ToggleButtons::make('tag_ids')
+                            ->multiple()
+                            ->default(fn (?Patient $record) => $record?->tags->pluck('id')->map(fn ($id) => (string) $id)->all())
+                            ->options(fn () => \App\Models\Tag::pluck('name', 'id')->toArray())
+                            ->icons(fn () => \App\Models\Tag::pluck('icon', 'id')->toArray())
+                            ->colors(fn () => \App\Models\Tag::pluck('color', 'id')->toArray()),
+                    ])
                 ])
             ]);
     }

--- a/app/Filament/Resources/Tags/Schemas/TagForm.php
+++ b/app/Filament/Resources/Tags/Schemas/TagForm.php
@@ -2,15 +2,32 @@
 
 namespace App\Filament\Resources\Tags\Schemas;
 
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
 use Filament\Schemas\Schema;
+use Filament\Support\Colors\Color;
+use Filament\Support\Icons\Heroicon;
 
 class TagForm
 {
     public static function configure(Schema $schema): Schema
     {
+        $colors = array_keys(Color::all());
+
         return $schema
             ->components([
-                //
+                TextInput::make('name')
+                    ->required(),
+                Textarea::make('description'),
+                Select::make('color')
+                    ->options(array_combine($colors, array_map('ucfirst', $colors)))
+                    ->searchable()
+                    ->required(),
+                Select::make('icon')
+                    ->options(Heroicon::class)
+                    ->searchable()
+                    ->required(),
             ]);
     }
 }

--- a/app/Filament/Resources/Tags/Tables/TagsTable.php
+++ b/app/Filament/Resources/Tags/Tables/TagsTable.php
@@ -7,6 +7,9 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ForceDeleteBulkAction;
 use Filament\Actions\RestoreBulkAction;
+use Filament\Tables\Columns\ColorColumn;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 
@@ -16,7 +19,27 @@ class TagsTable
     {
         return $table
             ->columns([
-                //
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('description')
+                    ->limit(50)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                ColorColumn::make('color'),
+                IconColumn::make('icon')
+                    ->icon(fn(string $state) => $state),
+                TextColumn::make('deleted_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 TrashedFilter::make(),

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use App\Models\Person;
 use App\Models\Organization;
 use App\Models\OrganizationPatient;
@@ -45,6 +46,12 @@ class Patient extends BaseModel
     public function organizations(): BelongsToMany
     {
         return $this->belongsToMany(Organization::class)->using(OrganizationPatient::class);
+    }
+
+    public function tags(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable')
+            ->using(Taggable::class);
     }
 
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -2,10 +2,27 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
 class Tag extends BaseModel
 {
-    public function organization()
+    protected $fillable = [
+        'organization_id',
+        'name',
+        'description',
+        'color',
+        'icon',
+    ];
+
+    public function organization(): BelongsTo
     {
         return $this->belongsTo(Organization::class);
+    }
+
+    public function patients(): MorphToMany
+    {
+        return $this->morphedByMany(Patient::class, 'taggable')
+            ->using(Taggable::class);
     }
 }

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tag;
+use App\Models\Organization;
+use Filament\Support\Colors\Color;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TagFactory extends Factory
+{
+    protected $model = Tag::class;
+
+    public function definition(): array
+    {
+        $colors = array_keys(Color::all());
+        $icons = array_column(Heroicon::cases(), 'value');
+
+        return [
+            'organization_id' => Organization::factory(),
+            'name' => $this->faker->word,
+            'description' => $this->faker->sentence,
+            'color' => $this->faker->randomElement($colors),
+            'icon' => $this->faker->randomElement($icons),
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Organization;
 use App\Models\Person;
 use App\Models\Patient;
 use App\Models\PractitionerQualification;
+use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 
@@ -43,6 +44,10 @@ class DatabaseSeeder extends Seeder
                 ->each(function (Patient $patient) use ($organization) {
                     $patient->organizations()->attach($organization);
                 });
+
+            Tag::factory(random_int(2, 5))
+                ->for($organization)
+                ->create();
         });
     }
 }


### PR DESCRIPTION
## Summary
- implement Tag form schema and table columns
- allow patients to be tagged with existing tags via toggle buttons
- sync tags on create & edit patient pages
- add TagFactory and seed tags for organizations
- expand Tag and Patient models for tag relations

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684a0e8eaea88328be607049f1aa6c32