### PR TITLE
Update README for Filament 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Zero-knowledge encryption. You own your data.
 
 - **Laravel 12+**
 - **PostgreSQL 17+**
-- **Filament 3**
+- **Filament 4**
+
+The `composer.json` file lists Laravel 12 and Filament v4 as core dependencies.
 
 ---
 


### PR DESCRIPTION
## Summary
- update README to reference Filament 4 instead of Filament 3
- note that composer.json specifies Laravel 12 and Filament v4

## Testing
- `composer test` *(fails: ComponentNotFoundException)*
- `./vendor/bin/pint --test` *(fails: 102 files with style issues)*

------
https://chatgpt.com/codex/tasks/task_e_684eea532cbc83289db0afbbd8455fc5