### PR TITLE
Fix binary organization name cast

### DIFF
--- a/app/Feature/End2EndEncryption/Casts/EncryptedBinary.php
+++ b/app/Feature/End2EndEncryption/Casts/EncryptedBinary.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Feature\End2EndEncryption\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Facades\Crypt;
+
+class EncryptedBinary implements CastsAttributes
+{
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return is_null($value)
+            ? null
+            : Crypt::decryptString(base64_encode($value));
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return is_null($value)
+            ? null
+            : base64_decode(Crypt::encryptString($value));
+    }
+}

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -2,28 +2,16 @@
 
 namespace App\Models;
 
-use Illuminate\Support\Carbon;
-use Illuminate\Database\Eloquent\Collection;
+use App\Feature\End2EndEncryption\Casts\EncryptedBinary;
+use App\Feature\Identity\Enums\OrganizationType;
 use Database\Factories\OrganizationFactory;
 use Illuminate\Database\Eloquent\Builder;
-use App\Feature\Identity\Enums\OrganizationType;
-use App\Feature\Revision\Interfaces\Revisionable;
-use App\Feature\Revision\Observers\RevisionableObserver;
-use App\Feature\Revision\Traits\LogsRevisions;
-use App\Feature\Sqid\Interfaces\Sqidable;
-use App\Feature\Sqid\Traits\HasSqids;
-use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use App\Models\Practitioner;
-use App\Models\OrganizationPractitioner;
-use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
 /**
- *
- *
  * @property int $id
  * @property OrganizationType $type
  * @property mixed $name
@@ -36,6 +24,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property-read OrganizationPractitioner|null $pivot
  * @property-read Collection<int, Practitioner> $practitioners
  * @property-read int|null $practitioners_count
+ *
  * @method static OrganizationFactory factory($count = null, $state = [])
  * @method static Builder<static>|Organization newModelQuery()
  * @method static Builder<static>|Organization newQuery()
@@ -49,13 +38,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static Builder<static>|Organization whereUpdatedAt($value)
  * @method static Builder<static>|Organization withTrashed()
  * @method static Builder<static>|Organization withoutTrashed()
+ *
  * @mixin \Eloquent
  */
 class Organization extends BaseModel
 {
     protected $casts = [
         'type' => OrganizationType::class,
-        'name' => 'encrypted',
+        'name' => EncryptedBinary::class,
     ];
 
     protected $fillable = [

--- a/tests/Feature/EncryptedBinaryCastTest.php
+++ b/tests/Feature/EncryptedBinaryCastTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\Organization;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+it('stores encrypted data as binary and decrypts on retrieval', function () {
+    $org = Organization::factory()->create(['name' => 'Secret']);
+
+    $raw = DB::table('organizations')->where('id', $org->id)->value('name');
+
+    expect($raw)->not->toBe('Secret');
+    expect(Crypt::decryptString(base64_encode($raw)))->toBe('Secret');
+
+    $org->refresh();
+    expect($org->name)->toBe('Secret');
+});


### PR DESCRIPTION
## Summary
- implement `EncryptedBinary` cast to handle raw binary encryption
- use new cast for `Organization` name
- add regression test for binary encryption

## Testing
- `composer install --no-interaction`
- `npm install`
- `npm run build`
- `php artisan test` *(fails: ComponentNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6853d291bccc83289b91307701879318