### PR TITLE
Add patient resource with person schema

### DIFF
--- a/app/Filament/Auth/Pages/EditProfile.php
+++ b/app/Filament/Auth/Pages/EditProfile.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Auth\Pages;
 
 use App\Feature\Identity\Enums\Language;
+use App\Feature\Identity\Rules\ValidPesel;
 use Exception;
 use Filament\Auth\Pages\EditProfile as BaseEditProfile;
 use Filament\Forms\Components\Select;
@@ -10,7 +11,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Schema;
-use App\Feature\Identity\Rules\ValidPesel;
 
 class EditProfile extends BaseEditProfile
 {
@@ -53,7 +53,7 @@ class EditProfile extends BaseEditProfile
         return TextInput::make('pesel')
             ->label(__('doceus.user.pesel'))
             ->required()
-            ->rule(new ValidPesel());
+            ->rule(new ValidPesel);
     }
 
     /**
@@ -91,11 +91,7 @@ class EditProfile extends BaseEditProfile
     {
         return Group::make()
             ->relationship('person')
-            ->schema([
-                $this->getFirstNameFormComponent(),
-                $this->getLastNameFormComponent(),
-                $this->getPeselFormComponent(),
-            ]);
+            ->schema(\App\People\Schemas\PersonSchema::make()->getComponents());
     }
 
     protected function getRedirectUrl(): ?string

--- a/app/Filament/Resources/PatientResource.php
+++ b/app/Filament/Resources/PatientResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PatientResource\Pages;
+use App\Models\Patient;
+use App\People\Schemas\PersonSchema;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Group;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class PatientResource extends Resource
+{
+    protected static ?string $model = Patient::class;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Group::make()
+                ->relationship('person')
+                ->schema(PersonSchema::make()->getComponents()),
+            TextInput::make('email')
+                ->label(__('doceus.user.email'))
+                ->email()
+                ->required(),
+            TextInput::make('phone_number')
+                ->label(__('doceus.user.phone'))
+                ->tel()
+                ->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('person.first_name')
+                ->label(__('doceus.user.first_name'))
+                ->sortable()
+                ->searchable(),
+            TextColumn::make('person.last_name')
+                ->label(__('doceus.user.last_name'))
+                ->sortable()
+                ->searchable(),
+            TextColumn::make('email')
+                ->label(__('doceus.user.email')),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPatients::route('/'),
+            'create' => Pages\CreatePatient::route('/create'),
+            'edit' => Pages\EditPatient::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PatientResource/Pages/CreatePatient.php
+++ b/app/Filament/Resources/PatientResource/Pages/CreatePatient.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\PatientResource\Pages;
+
+use App\Filament\Resources\PatientResource;
+use App\Models\Person;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+
+class CreatePatient extends CreateRecord
+{
+    protected static string $resource = PatientResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $personData = $data['person'] ?? [];
+        unset($data['person']);
+
+        $person = Person::create($personData);
+        $data['person_id'] = $person->id;
+
+        return static::getModel()::create($data);
+    }
+}

--- a/app/Filament/Resources/PatientResource/Pages/EditPatient.php
+++ b/app/Filament/Resources/PatientResource/Pages/EditPatient.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PatientResource\Pages;
+
+use App\Filament\Resources\PatientResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPatient extends EditRecord
+{
+    protected static string $resource = PatientResource::class;
+}

--- a/app/Filament/Resources/PatientResource/Pages/ListPatients.php
+++ b/app/Filament/Resources/PatientResource/Pages/ListPatients.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PatientResource\Pages;
+
+use App\Filament\Resources\PatientResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPatients extends ListRecords
+{
+    protected static string $resource = PatientResource::class;
+}

--- a/app/People/Schemas/PersonSchema.php
+++ b/app/People/Schemas/PersonSchema.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\People\Schemas;
+
+use App\Feature\Identity\Enums\Gender;
+use App\Feature\Identity\Enums\IdentityType;
+use App\Feature\Identity\Rules\ValidPesel;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+
+class PersonSchema extends Schema
+{
+    public function configure(): static
+    {
+        return $this->schema([
+            TextInput::make('first_name')
+                ->label(__('doceus.user.first_name'))
+                ->required(),
+            TextInput::make('last_name')
+                ->label(__('doceus.user.last_name'))
+                ->required(),
+            TextInput::make('pesel')
+                ->label(__('doceus.user.pesel'))
+                ->required()
+                ->rule(new ValidPesel),
+            TextInput::make('identity_number')
+                ->label(__('doceus.id_number')),
+            Select::make('identity_type')
+                ->label('Identity Type')
+                ->options(collect(IdentityType::cases())->mapWithKeys(fn ($case) => [$case->value => $case->value])),
+            Select::make('gender')
+                ->label(__('doceus.gender.label'))
+                ->options(Gender::class),
+            DatePicker::make('birth_date')
+                ->label(__('doceus.birth_date')),
+        ]);
+    }
+}

--- a/lang/en/doceus.php
+++ b/lang/en/doceus.php
@@ -25,6 +25,10 @@ return [
         'individual' => 'Individual',
         'entity' => 'Entity',
     ],
+    'patient' => [
+        'label' => 'Patient',
+        'plural_label' => 'Patients',
+    ],
     'user_feature' => [
         'is_medical_doctor' => 'Medical doctor',
         'is_medical_assistant' => 'Medical assistant',

--- a/lang/pl/doceus.php
+++ b/lang/pl/doceus.php
@@ -25,6 +25,10 @@ return [
         'individual' => 'Osoba indywidualna',
         'entity' => 'Jednostka',
     ],
+    'patient' => [
+        'label' => 'Pacjent',
+        'plural_label' => 'Pacjenci',
+    ],
     'user_feature' => [
         'is_medical_doctor' => 'Lekarz',
         'is_medical_assistant' => 'Asystent medyczny',


### PR DESCRIPTION
## Summary
- implement `PersonSchema` for reusable person form fields
- create `PatientResource` with CRUD pages
- ensure a unique `Person` record is created when adding a patient
- reuse `PersonSchema` in Edit Profile form
- add patient labels in translation files

## Testing
- `composer install --no-interaction`
- `composer test`
- `./vendor/bin/pint`

------
https://chatgpt.com/codex/tasks/task_e_6854958f1a188328aaf7b04541f1685a