### PR TITLE
Embed person data in patient forms

### DIFF
--- a/app/Filament/Resources/Patients/Pages/CreatePatient.php
+++ b/app/Filament/Resources/Patients/Pages/CreatePatient.php
@@ -3,9 +3,21 @@
 namespace App\Filament\Resources\Patients\Pages;
 
 use App\Filament\Resources\Patients\PatientResource;
+use App\Models\Person;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreatePatient extends CreateRecord
 {
     protected static string $resource = PatientResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $personData = Arr::pull($data, 'person', []);
+        $person = Person::create($personData);
+        $data['person_id'] = $person->id;
+
+        return parent::handleRecordCreation($data);
+    }
 }

--- a/app/Filament/Resources/Patients/Pages/EditPatient.php
+++ b/app/Filament/Resources/Patients/Pages/EditPatient.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\Patients\Pages;
 
 use App\Filament\Resources\Patients\PatientResource;
+use Illuminate\Support\Arr;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\RestoreAction;
@@ -11,6 +12,14 @@ use Filament\Resources\Pages\EditRecord;
 class EditPatient extends EditRecord
 {
     protected static string $resource = PatientResource::class;
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $personData = Arr::pull($data, 'person', []);
+        $this->record->person->update($personData);
+
+        return $data;
+    }
 
     protected function getHeaderActions(): array
     {

--- a/app/Filament/Resources/Patients/Schemas/PatientForm.php
+++ b/app/Filament/Resources/Patients/Schemas/PatientForm.php
@@ -2,8 +2,9 @@
 
 namespace App\Filament\Resources\Patients\Schemas;
 
-use Filament\Forms\Components\Select;
+use App\Filament\Resources\People\Schemas\PersonForm;
 use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Group;
 use Filament\Schemas\Schema;
 
 class PatientForm
@@ -12,9 +13,9 @@ class PatientForm
     {
         return $schema
             ->components([
-                Select::make('person_id')
-                    ->relationship('person', 'id')
-                    ->required(),
+                Group::make()
+                    ->statePath('person')
+                    ->schema(PersonForm::configure(Schema::make())->getComponents()),
                 TextInput::make('email')
                     ->email()
                     ->required(),

--- a/app/Filament/Resources/Patients/Tables/PatientsTable.php
+++ b/app/Filament/Resources/Patients/Tables/PatientsTable.php
@@ -17,9 +17,10 @@ class PatientsTable
     {
         return $table
             ->columns([
-                TextColumn::make('person.id')
-                    ->numeric()
-                    ->sortable(),
+                TextColumn::make('person.first_name')
+                    ->label('First name'),
+                TextColumn::make('person.last_name')
+                    ->label('Last name'),
                 TextColumn::make('email'),
                 TextColumn::make('phone_number'),
                 TextColumn::make('created_at')

--- a/database/migrations/2025_06_19_231626_update_patients_table_add_unique_person.php
+++ b/database/migrations/2025_06_19_231626_update_patients_table_add_unique_person.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('patients', function (Blueprint $table) {
+            $table->dropIndex(['person_id']);
+            $table->unique('person_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('patients', function (Blueprint $table) {
+            $table->dropUnique(['person_id']);
+            $table->index('person_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- embed `PersonForm` in patient form
- create a fresh `Person` during patient creation
- update `Person` data when editing a patient
- show patient names in table
- ensure each patient references a unique person

## Testing
- `composer install --ansi --no-interaction`
- `composer test --ansi`

------
https://chatgpt.com/codex/tasks/task_e_6854990ead988328aad76f24c78e25e0