### PR TITLE
Add custom verification and logout

### DIFF
--- a/app/Filament/Auth/Pages/EmailVerificationPrompt.php
+++ b/app/Filament/Auth/Pages/EmailVerificationPrompt.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Filament\Auth\Pages;
+
+use Filament\Actions\Action;
+use Filament\Auth\Pages\EmailVerification\EmailVerificationPrompt as BaseEmailVerificationPrompt;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Text;
+use Filament\Schemas\Schema;
+use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\HtmlString;
+
+class EmailVerificationPrompt extends BaseEmailVerificationPrompt
+{
+    public function logoutAction(): Action
+    {
+        return Action::make('logout')
+            ->label(__('filament-panels::layout.actions.logout.label'))
+            ->icon(FilamentIcon::resolve('panels::user-menu.logout-button') ?? Heroicon::ArrowLeftOnRectangle)
+            ->url(filament()->getLogoutUrl())
+            ->postToUrl();
+    }
+
+    public function content(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Text::make(__('filament-panels::auth/pages/email-verification/email-verification-prompt.messages.notification_sent', [
+                    'email' => filament()->auth()->user()->getEmailForVerification(),
+                ])),
+                Text::make(new HtmlString(
+                    __('filament-panels::auth/pages/email-verification/email-verification-prompt.messages.notification_not_received').
+                    ' '.
+                    $this->resendNotificationAction->toHtml(),
+                )),
+                Actions::make([
+                    $this->logoutAction(),
+                ])->fullWidth(),
+            ]);
+    }
+}

--- a/app/Http/Middleware/EnsureEmailVerified.php
+++ b/app/Http/Middleware/EnsureEmailVerified.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureEmailVerified
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+
+        if ($user && ! $user->hasVerifiedEmail() && ! $request->routeIs('filament.app.auth.email-verification.prompt')) {
+            return redirect()->route('filament.app.auth.email-verification.prompt');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/Filament/PractitionerPanelProvider.php
+++ b/app/Providers/Filament/PractitionerPanelProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Auth\Pages\EditProfile;
-use App\Filament\Auth\Pages\Register;
 use App\Http\Middleware\EnsureProfileComplete;
 use App\Http\Middleware\SetUserLocale;
 use App\Models\Organization;
@@ -42,7 +41,7 @@ class PractitionerPanelProvider extends PanelProvider
             ->passwordReset()
             ->profile(EditProfile::class)
             ->registration(\App\Filament\Auth\Pages\Register::class)
-            ->emailVerification()
+            ->emailVerification(\App\Filament\Auth\Pages\EmailVerificationPrompt::class)
             ->emailChangeVerification()
             ->login()
             ->colors([
@@ -65,6 +64,7 @@ class PractitionerPanelProvider extends PanelProvider
                 AddQueuedCookiesToResponse::class,
                 StartSession::class,
                 SetUserLocale::class,
+                \App\Http\Middleware\EnsureEmailVerified::class,
                 EnsureProfileComplete::class,
                 AuthenticateSession::class,
                 ShareErrorsFromSession::class,

--- a/tests/Feature/EnsureEmailVerifiedMiddlewareTest.php
+++ b/tests/Feature/EnsureEmailVerifiedMiddlewareTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Practitioner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('redirects to email verification when not verified', function () {
+    $practitioner = Practitioner::factory()->unverified()->create();
+
+    $response = $this->actingAs($practitioner)->get('/');
+
+    $response->assertRedirect(route('filament.app.auth.email-verification.prompt'));
+});
+
+it('allows access when verified', function () {
+    $practitioner = Practitioner::factory()->create();
+
+    $response = $this->actingAs($practitioner)->get('/');
+
+    $response->assertStatus(302);
+    expect($response->headers->get('Location'))->not->toBe(route('filament.app.auth.email-verification.prompt'));
+});
+
+it('allows email verification prompt for unverified user', function () {
+    $practitioner = Practitioner::factory()->unverified()->create();
+
+    $response = $this->actingAs($practitioner)->get(route('filament.app.auth.email-verification.prompt'));
+
+    $response->assertSuccessful();
+});


### PR DESCRIPTION
## Summary
- customize email verification page and add logout action
- ensure unverified users are redirected
- cover new middleware with tests

## Testing
- `composer test`
- `./vendor/bin/pint --test app/Filament/Auth/Pages/EmailVerificationPrompt.php app/Providers/Filament/PractitionerPanelProvider.php app/Http/Middleware/EnsureEmailVerified.php tests/Feature/EnsureEmailVerifiedMiddlewareTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68554b87a4e08328b026cfb062cd68a2